### PR TITLE
Include dependencies and globalize variables

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
-const btoa = require('btoa');
-const atob = require('atob');
-const Promise = require('es6-promise').Promise;
-const openpgp = require('openpgp');
+global.btoa = require('btoa');
+global.atob = require('atob');
+global.Promise = require('es6-promise').Promise;
+global.openpgp = require('openpgp');
 
 openpgp.config.integrity_protect = true;
 openpgp.config.use_native = true;

--- a/package.json
+++ b/package.json
@@ -17,6 +17,12 @@
     "url": "https://github.com/ProtonMail/pmcrypto/issues"
   },
   "homepage": "https://github.com/ProtonMail/pmcrypto#readme",
+  "dependencies": {
+	  "btoa": "*",
+	  "atob": "*",
+	  "es6-promise": "*",
+	  "openpgp": "*"
+  },
   "devDependencies": {
     "babel-plugin-istanbul": "^4.1.4",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",


### PR DESCRIPTION
Include the dependencies in package.json and make openpgp, btoa, atob, and Promise global.