### PR TITLE
Rename message date param from `date` to `messageDate`

### DIFF
--- a/lib/message/decrypt.js
+++ b/lib/message/decrypt.js
@@ -35,7 +35,7 @@ export async function decryptMessage(options) {
 // Backwards-compatible decrypt message function
 // 'message' option must be a string!
 export async function decryptMessageLegacy(options) {
-    if (options.date === undefined || !(options.date instanceof Date)) {
+    if (options.messageDate === undefined || !(options.messageDate instanceof Date)) {
         throw new Error('Missing message time');
     }
 
@@ -67,7 +67,7 @@ export async function decryptMessageLegacy(options) {
     const params = { signature: 0 };
 
     // cutoff time for enabling multilanguage support
-    if (+options.date > 1399086120000) {
+    if (+options.messageDate > 1399086120000) {
         params.data = decodeUtf8Base64(
             arrayToBinaryString(openpgp.crypto.cfb.decrypt('aes256', randomKey, oldEncMessage, true))
         );


### PR DESCRIPTION
So that signatures are verified against the current date by default.