### PR TITLE
Add pm-srp required exports

### DIFF
--- a/lib/message/processMIME.js
+++ b/lib/message/processMIME.js
@@ -1,5 +1,5 @@
 import MailParser from './mailparser';
-import { getSignature, verifyMessage, getCleartextMessage } from './utils';
+import { getSignature, verifyMessage, createCleartextMessage } from './utils';
 import { VERIFICATION_STATUS, MAX_ENC_HEADER_LENGTH } from '../constants';
 
 /**
@@ -44,7 +44,7 @@ const verifySignature = async ({ publicKeys, date }, data) => {
     const body = parts[1];
 
     const { data: subdata, verified } = await verifyMessage({
-        message: getCleartextMessage(body),
+        message: createCleartextMessage(body),
         publicKeys,
         date,
         signature

--- a/lib/message/utils.js
+++ b/lib/message/utils.js
@@ -22,7 +22,8 @@ export async function getMessage(message) {
 
 /**
  * Prepare signature
- * @param {Promise<Object>} message
+ * @param {String|Uint8Array|openpgp.signature.Signature} signature
+ * @return {Promise<openpgp.signature.Signature>}
  */
 export async function getSignature(signature) {
     if (openpgp.signature.Signature.prototype.isPrototypeOf(signature)) {
@@ -33,11 +34,28 @@ export async function getSignature(signature) {
     return openpgp.signature.readArmored(signature.trim());
 }
 
-export function getCleartextMessage(message) {
+/**
+ * Read a cleartext message from an armored message.
+ * @param {String|openpgp.cleartext.CleartextMessage} message
+ * @return {Promise<openpgp.cleartext.CleartextMessage>}
+ */
+export async function getCleartextMessage(message) {
     if (openpgp.cleartext.CleartextMessage.prototype.isPrototypeOf(message)) {
         return message;
     }
-    return new openpgp.cleartext.CleartextMessage(message);
+    return openpgp.cleartext.readArmored(message.trim());
+}
+
+/**
+ * Create a cleartext message from a text.
+ * @param {String|openpgp.cleartext.CleartextMessage} message
+ * @return {openpgp.cleartext.CleartextMessage}
+ */
+export function createCleartextMessage(message) {
+    if (openpgp.cleartext.CleartextMessage.prototype.isPrototypeOf(message)) {
+        return message;
+    }
+    return openpgp.cleartext.fromText(message);
 }
 
 export function createMessage(source, filename, date = serverTime()) {
@@ -49,7 +67,7 @@ export function createMessage(source, filename, date = serverTime()) {
 
 export function signMessage(options) {
     if (typeof options.data === 'string') {
-        options.message = getCleartextMessage(options.data);
+        options.message = createCleartextMessage(options.data);
     }
 
     if (Uint8Array.prototype.isPrototypeOf(options.data)) {

--- a/lib/pmcrypto.js
+++ b/lib/pmcrypto.js
@@ -20,7 +20,6 @@ export {
     encodeBase64,
     decodeBase64,
     concatArrays,
-    getHashedPassword,
     arrayToBinaryString,
     arrayToHexString,
     binaryStringToArray,

--- a/lib/pmcrypto.js
+++ b/lib/pmcrypto.js
@@ -24,6 +24,8 @@ export {
     arrayToBinaryString,
     binaryStringToArray,
     stripArmor,
+    sha512,
+    md5,
     createWorker
 } from './utils';
 

--- a/lib/pmcrypto.js
+++ b/lib/pmcrypto.js
@@ -22,6 +22,7 @@ export {
     concatArrays,
     getHashedPassword,
     arrayToBinaryString,
+    arrayToHexString,
     binaryStringToArray,
     stripArmor,
     sha512,

--- a/lib/pmcrypto.js
+++ b/lib/pmcrypto.js
@@ -24,8 +24,8 @@ export {
     arrayToHexString,
     binaryStringToArray,
     stripArmor,
-    sha512,
-    md5,
+    SHA512,
+    unsafeMD5,
     createWorker
 } from './utils';
 

--- a/lib/pmcrypto.js
+++ b/lib/pmcrypto.js
@@ -58,6 +58,7 @@ export {
     splitMessage,
     verifyMessage,
     getCleartextMessage,
+    createCleartextMessage,
     createMessage,
     armorBytes
 } from './message/utils';

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -18,6 +18,7 @@ export const decodeUtf8Base64 = ifDefined((input) => decodeUtf8(decodeBase64(inp
 
 export const binaryStringToArray = (args) => openpgp.util.str_to_Uint8Array(args);
 export const arrayToBinaryString = (args) => openpgp.util.Uint8Array_to_str(args); // eslint-disable-line new-cap
+export const arrayToHexString = (args) => openpgp.util.Uint8Array_to_hex(args); // eslint-disable-line new-cap
 export const concatArrays = (args) => openpgp.util.concatUint8Array(args);
 
 export const sha512 = (args) => openpgp.crypto.hash.sha512(args);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -21,8 +21,13 @@ export const arrayToBinaryString = (args) => openpgp.util.Uint8Array_to_str(args
 export const arrayToHexString = (args) => openpgp.util.Uint8Array_to_hex(args); // eslint-disable-line new-cap
 export const concatArrays = (args) => openpgp.util.concatUint8Array(args);
 
-export const sha512 = (args) => openpgp.crypto.hash.sha512(args);
-export const md5 = (args) => openpgp.crypto.hash.md5(args);
+export const SHA512 = (args) => openpgp.crypto.hash.sha512(args);
+/**
+ * MD5 is an unsafe hash function. It should normally not be used.
+ * It's exposed because it's required for old auth versions.
+ * @see openpgp.crypto.hash.md5
+ */
+export const unsafeMD5 = (args) => openpgp.crypto.hash.md5(args);
 
 /**
  * Dearmor a pgp encoded message.

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -24,9 +24,6 @@ export const concatArrays = (args) => openpgp.util.concatUint8Array(args);
 export const sha512 = (args) => openpgp.crypto.hash.sha512(args);
 export const md5 = (args) => openpgp.crypto.hash.md5(args);
 
-export const getHashedPassword = (password) =>
-    localBtoa(arrayToBinaryString(openpgp.crypto.hash.sha512(binaryStringToArray(password))));
-
 /**
  * Dearmor a pgp encoded message.
  * @param {String} input

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -20,6 +20,9 @@ export const binaryStringToArray = (args) => openpgp.util.str_to_Uint8Array(args
 export const arrayToBinaryString = (args) => openpgp.util.Uint8Array_to_str(args); // eslint-disable-line new-cap
 export const concatArrays = (args) => openpgp.util.concatUint8Array(args);
 
+export const sha512 = (args) => openpgp.crypto.hash.sha512(args);
+export const md5 = (args) => openpgp.crypto.hash.md5(args);
+
 export const getHashedPassword = (password) =>
     localBtoa(arrayToBinaryString(openpgp.crypto.hash.sha512(binaryStringToArray(password))));
 


### PR DESCRIPTION
Adds:
* SHA512 hash, exposed as `SHA512`
* MD5 hash, exposed as `unsafeMD5`
* `arrayToHexString`
* `createCleartextMessage`

Changes:
* `getCleartextMessage` now reads an armored message instead of creating one. To create one the `createCleartextMessage` should be used. This is to have consistency with the `getMessage`, `createMessage`, `getSignature` etc functions. It does not seem to be used in the encryption server, it is used in the Angular project so it needs to be updated there.

Removes:
* `getHashedPassword` it's broken and not used in pmcrypto, encryption-server or angular.