### PR TITLE
Fix date check expiration test

### DIFF
--- a/lib/key/info.js
+++ b/lib/key/info.js
@@ -90,7 +90,7 @@ export default async function keyInfo(rawKey, email, expectEncrypted = true, dat
     }
 
     try {
-        dateChecks(keys);
+        dateChecks(keys, date);
     } catch (err) {
         obj.dateError = err.message;
     }

--- a/test/key/info.spec.js
+++ b/test/key/info.spec.js
@@ -70,6 +70,11 @@ uokpJQHZjIvfQ5/9tx1946Tvo0RX0A26JfOO+J68XA==
 -----END PGP PUBLIC KEY BLOCK-----`;
 
 test('creation test', async (t) => {
-    const { dateError } = await pmcrypto.keyInfo(creationkey);
+    const { dateError } = await pmcrypto.keyInfo(
+        creationkey,
+        undefined,
+        undefined,
+        new Date('2019-01-01T00:00:00.000Z')
+    );
     t.is(dateError, 'The self certifications are created with illegal times');
 });


### PR DESCRIPTION
The date of the key passed  the current date so the test did not fail anymore.

Also, the date used in keyInfo was not passed to the dateChecks function.