### PR TITLE
Fix #53 - Signature mime parsing

### DIFF
--- a/lib/message/processMIME.js
+++ b/lib/message/processMIME.js
@@ -30,15 +30,16 @@ const verifySignature = async ({ publicKeys, date }, data) => {
     }
     const boundary = rawboundary[0] === '"' ? JSON.parse(rawboundary) || rawboundary : rawboundary;
     const parts = data.split(new RegExp(`\n--${boundary}(?:--)?\n`, 'g'));
-    if (!parts.length === 4) {
+    if (parts.length !== 3) {
         return { subdata: data, verified: 0 };
     }
-    const { attachments: [sigAttachment] = [] } = await parseMail(parts[2].trim());
+    const { attachments: [sigAttachment = {}] = [] } = await parseMail(parts[2].trim());
 
-    if (sigAttachment.contentType.toLowerCase() !== 'application/pgp-signature') {
+    const { contentType: sigAttachmentContentType = '', content: sigAttachmentContent = '' } = sigAttachment;
+    if (sigAttachmentContentType.toLowerCase() !== 'application/pgp-signature') {
         return { subdata: data, verified: 0 };
     }
-    const sigData = sigAttachment.content.toString();
+    const sigData = sigAttachmentContent.toString();
 
     const signature = await getSignature(sigData);
     const body = parts[1];

--- a/lib/message/processMIME.js
+++ b/lib/message/processMIME.js
@@ -30,7 +30,7 @@ const verifySignature = async ({ publicKeys, date }, data) => {
     }
     const boundary = rawboundary[0] === '"' ? JSON.parse(rawboundary) || rawboundary : rawboundary;
     const parts = data.split(new RegExp(`\n--${boundary}(?:--)?\n`, 'g'));
-    if (parts.length !== 3) {
+    if (parts.length < 3) {
         return { subdata: data, verified: 0 };
     }
     const { attachments: [sigAttachment = {}] = [] } = await parseMail(parts[2].trim());

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     ],
     "files": [
       "test/**/*.js",
+      "!test/**/*.data.js",
       "!test/helper.js"
     ]
   },

--- a/test/key/processMIME.data.js
+++ b/test/key/processMIME.data.js
@@ -81,3 +81,32 @@ that the message signature is not invalidated when passing
 a gateway that modifies such whitespace (like BITNET).  
 
 me`;
+
+export const extraMultipartSignedMessage = `From: Jon Smith <jon@example.com>
+To: Jon Smith <jon@example.com>
+Mime-Version: 1.0
+Content-Type: multipart/signed; boundary=bar; micalg=pgp-md5;
+protocol="application/pgp-signature"
+
+--bar
+Content-Type: text/plain; charset=iso-8859-1
+Content-Transfer-Encoding: quoted-printable
+
+hello
+--bar
+
+Content-Type: application/pgp-signature
+
+-----BEGIN PGP SIGNATURE-----
+Version: OpenPGP.js v4.4.6
+Comment: https://openpgpjs.org
+
+wl4EARYKAAYFAlxuurAACgkQApgazZlru7PubwEAkm2yNgMcCzv9YuW2zKEP
+eo6TtHjWxF3GASwuZ/nMv/MBAJUDDC3PDfCIGyPKk2Pzf2t2co/+dEpW3vpx
+euiL4uYD
+=97+O
+-----END PGP SIGNATURE-----
+
+--bar
+extra part
+--bar--`;

--- a/test/key/processMIME.data.js
+++ b/test/key/processMIME.data.js
@@ -1,0 +1,83 @@
+export const key = `-----BEGIN PGP PUBLIC KEY BLOCK-----
+Version: OpenPGP.js v4.4.6
+Comment: https://openpgpjs.org
+
+xjMEXG6rNhYJKwYBBAHaRw8BAQdA63eiHJ6ylmHXwDzvNoBXDx3UkaF6rm3d
+kToIFs8KYGnNG0pvbiBTbWl0aCA8am9uQGV4YW1wbGUuY29tPsJ3BBAWCgAf
+BQJcbqs2BgsJBwgDAgQVCAoCAxYCAQIZAQIbAwIeAQAKCRACmBrNmWu7s6ig
+AP4l4JUNFYP1lzje4+VB1oz3xgAJwDpIPnpvV4p6fVfCMQEAsfqvA6OdgLl+
+MmVRBRXO1BUtkSxwS9zxzQfE/0NZ7QfOOARcbqs2EgorBgEEAZdVAQUBAQdA
+4IcImEOmtilzNy6BvjyoHHtiukYZlb4/38iqQbzQxywDAQgHwmEEGBYIAAkF
+AlxuqzYCGwwACgkQApgazZlru7OCeAD/Waa1g7t1DsrE8Di+ovD19Xs7js4R
+82uvdzLBXafN8okBALL5uHCjG/gkJzHGun2Tj2MKO2ykR6gv6lVKo7jX75kD
+=7vY3
+-----END PGP PUBLIC KEY BLOCK-----`;
+
+export const multipartSignedMessage = `From: Jon Smith <jon@example.com>
+To: Jon Smith <jon@example.com>
+Mime-Version: 1.0
+Content-Type: multipart/signed; boundary=bar; micalg=pgp-md5;
+protocol="application/pgp-signature"
+
+--bar
+Content-Type: text/plain; charset=iso-8859-1
+Content-Transfer-Encoding: quoted-printable
+
+=A1Hola!
+
+Did you know that talking to yourself is a sign of senility?
+
+It's generally a good idea to encode lines that begin with
+From=20because some mail transport agents will insert a greater-
+than (>) sign, thus invalidating the signature.
+
+Also, in some cases it might be desirable to encode any   =20
+trailing whitespace that occurs on lines in order to ensure  =20
+that the message signature is not invalidated when passing =20
+a gateway that modifies such whitespace (like BITNET). =20
+
+me
+--bar
+
+Content-Type: application/pgp-signature
+
+-----BEGIN PGP SIGNATURE-----
+Version: OpenPGP.js v4.4.6
+Comment: https://openpgpjs.org
+
+wl4EARYKAAYFAlxurnwACgkQApgazZlru7OZ4gEA7gcIhNDZe9DurcA7I6Hb
+J+mJL9vKtB5Ob4ponog5+ZYBAK6MCfmEImVCpdOlAIKmA9VRzQVLbW+Zm9cc
+iwVC3WsC
+=beyW
+-----END PGP SIGNATURE-----
+
+--bar--`;
+
+export const invalidMultipartSignedMessage = `From: Jon Smith <jon@example.com>
+To: Jon Smith <jon@example.com>
+Mime-Version: 1.0
+Content-Type: multipart/signed; boundary=bar; micalg=pgp-md5;
+protocol="application/pgp-signature"
+
+--bar
+Content-Type: text/plain; charset=iso-8859-1
+Content-Transfer-Encoding: quoted-printable
+
+message with missing signature
+--bar
+`;
+
+export const multipartSignedMessageBody = `¡Hola!
+
+Did you know that talking to yourself is a sign of senility?
+
+It's generally a good idea to encode lines that begin with
+From because some mail transport agents will insert a greater-
+than (>) sign, thus invalidating the signature.
+
+Also, in some cases it might be desirable to encode any    
+trailing whitespace that occurs on lines in order to ensure   
+that the message signature is not invalidated when passing  
+a gateway that modifies such whitespace (like BITNET).  
+
+me`;

--- a/test/key/processMIME.spec.js
+++ b/test/key/processMIME.spec.js
@@ -8,6 +8,7 @@ import {
     invalidMultipartSignedMessage,
     multipartSignedMessage,
     multipartSignedMessageBody,
+    extraMultipartSignedMessage,
     key
 } from './processMIME.data';
 
@@ -20,6 +21,17 @@ test('it can process multipart/signed mime messages and verify the signature', a
     );
     t.is(verified, VERIFICATION_STATUS.SIGNED_AND_VALID);
     t.is(body, multipartSignedMessageBody);
+});
+
+test('it can process multipart/signed mime messages and verify the signature with extra parts at the end', async (t) => {
+    const { body, verified } = await processMIME(
+        {
+            publicKeys: await getKeys(key)
+        },
+        extraMultipartSignedMessage
+    );
+    t.is(verified, VERIFICATION_STATUS.SIGNED_AND_VALID);
+    t.is(body, 'hello');
 });
 
 test('it does not verify invalid messages', async (t) => {

--- a/test/key/processMIME.spec.js
+++ b/test/key/processMIME.spec.js
@@ -1,0 +1,34 @@
+import test from 'ava';
+import '../helper';
+
+import processMIME from '../../lib/message/processMIME';
+import { getKeys } from '../../lib';
+import { VERIFICATION_STATUS } from '../../lib/constants';
+import {
+    invalidMultipartSignedMessage,
+    multipartSignedMessage,
+    multipartSignedMessageBody,
+    key
+} from './processMIME.data';
+
+test('it can process multipart/signed mime messages and verify the signature', async (t) => {
+    const { body, verified } = await processMIME(
+        {
+            publicKeys: await getKeys(key)
+        },
+        multipartSignedMessage
+    );
+    t.is(verified, VERIFICATION_STATUS.SIGNED_AND_VALID);
+    t.is(body, multipartSignedMessageBody);
+});
+
+test('it does not verify invalid messages', async (t) => {
+    const { verified, body } = await processMIME(
+        {
+            publicKeys: await getKeys(key)
+        },
+        invalidMultipartSignedMessage
+    );
+    t.is(verified, VERIFICATION_STATUS.NOT_SIGNED);
+    t.is(body, 'message with missing signature');
+});


### PR DESCRIPTION
According to https://tools.ietf.org/html/rfc3156#section-5 a signed message contains 3 parts. The header, the content, and the signature.

Changes:
* Check that the split boundary parts is at least 3, otherwise it's an invalid message.
* Handle empty signature part.
* Add tests for this function.