### PR TITLE
Fix boundary delimiter parsing

### DIFF
--- a/lib/message/processMIME.js
+++ b/lib/message/processMIME.js
@@ -29,7 +29,7 @@ const verifySignature = async ({ publicKeys, date }, data) => {
         return data;
     }
     const boundary = rawboundary[0] === '"' ? JSON.parse(rawboundary) || rawboundary : rawboundary;
-    const [mainPart] = data.split(`\n--${boundary}--`);
+    const [mainPart] = data.split(`\n--${boundary}--\n`);
     const parts = mainPart.split(`\n--${boundary}\n`);
     if (parts.length < 3) {
         return { subdata: data, verified: 0 };

--- a/lib/message/processMIME.js
+++ b/lib/message/processMIME.js
@@ -29,7 +29,8 @@ const verifySignature = async ({ publicKeys, date }, data) => {
         return data;
     }
     const boundary = rawboundary[0] === '"' ? JSON.parse(rawboundary) || rawboundary : rawboundary;
-    const parts = data.split(new RegExp(`\n--${boundary}(?:--)?\n`, 'g'));
+    const [mainPart] = data.split(`\n--${boundary}--`);
+    const parts = mainPart.split(`\n--${boundary}\n`);
     if (parts.length < 3) {
         return { subdata: data, verified: 0 };
     }

--- a/test/key/processMIME.data.js
+++ b/test/key/processMIME.data.js
@@ -110,3 +110,31 @@ euiL4uYD
 --bar
 extra part
 --bar--`;
+
+export const multiPartMessageWithSpecialCharacter = `From: Jon Smith <jon@example.com>
+To: Jon Smith <jon@example.com>
+Mime-Version: 1.0
+Content-Type: multipart/signed; boundary==-=pj+EhsWuSQJxx7=-=; micalg=pgp-md5;
+protocol="application/pgp-signature"
+
+--=-=pj+EhsWuSQJxx7=-=
+Content-Type: text/plain; charset=iso-8859-1
+Content-Transfer-Encoding: quoted-printable
+
+hello
+--=-=pj+EhsWuSQJxx7=-=
+
+Content-Type: application/pgp-signature
+
+-----BEGIN PGP SIGNATURE-----
+Version: OpenPGP.js v4.4.6
+Comment: https://openpgpjs.org
+
+wl4EARYKAAYFAlxuurAACgkQApgazZlru7PubwEAkm2yNgMcCzv9YuW2zKEP
+eo6TtHjWxF3GASwuZ/nMv/MBAJUDDC3PDfCIGyPKk2Pzf2t2co/+dEpW3vpx
+euiL4uYD
+=97+O
+-----END PGP SIGNATURE-----
+
+--=-=pj+EhsWuSQJxx7=-=
+`;

--- a/test/key/processMIME.spec.js
+++ b/test/key/processMIME.spec.js
@@ -9,6 +9,7 @@ import {
     multipartSignedMessage,
     multipartSignedMessageBody,
     extraMultipartSignedMessage,
+    multiPartMessageWithSpecialCharacter,
     key
 } from './processMIME.data';
 
@@ -43,4 +44,15 @@ test('it does not verify invalid messages', async (t) => {
     );
     t.is(verified, VERIFICATION_STATUS.NOT_SIGNED);
     t.is(body, 'message with missing signature');
+});
+
+test('it can parse messages with special characters in the boundary', async (t) => {
+    const { verified, body } = await processMIME(
+        {
+            publicKeys: await getKeys(key)
+        },
+        multiPartMessageWithSpecialCharacter
+    );
+    t.is(verified, VERIFICATION_STATUS.SIGNED_AND_VALID);
+    t.is(body, 'hello');
 });


### PR DESCRIPTION
Instead of creating a regexp with the boundary, and to avoid having to regex-escape it, split it two times.


Fix: https://github.com/ProtonMail/pmcrypto/issues/55