### PR TITLE
Fix #57 - Add support for getting key expiration type

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -10,3 +10,9 @@ export const SIGNATURE_TYPES = {
 };
 
 export const MAX_ENC_HEADER_LENGTH = 1024;
+
+export const EXPIRATION_TYPE = {
+    ENCRYPT: 'encrypt',
+    SIGN: 'sign',
+    ENCRYPT_SIGN: 'encrypt_sign'
+};

--- a/lib/key/info.js
+++ b/lib/key/info.js
@@ -1,50 +1,53 @@
 import { openpgp } from '../openpgp';
 import { dateChecks, keyCheck } from './check';
-import { getKeys } from './utils';
 import { serverTime } from '../serverTime';
+import { getKeys } from './utils';
 import { createMessage } from '../message/utils';
+import { EXPIRATION_TYPE } from '../constants';
 
-async function createPacketInfo(packet, subKey) {
+const getExpirationTime = (key, type) => {
+    return key.getExpirationTime(type).catch(() => undefined);
+};
+
+const createPacketInfo = async (packet, subKey, expirationType) => {
     return {
         algorithm: openpgp.enums.publicKey[packet.algorithm],
-        expires: await subKey.getExpirationTime('encrypt_sign')
+        expires: await getExpirationTime(subKey, expirationType)
     };
-}
+};
 
-const packetInfo = (packet, key) => {
+const getPacketInfo = (packet, key, expirationType) => {
     if (!packet) {
-        return null;
+        return;
     }
 
     if (key.subKeys) {
         for (let i = 0; i < key.subKeys.length; i++) {
             const subKey = key.subKeys[i];
             if (packet === key.subKeys[i].subKey) {
-                return createPacketInfo(packet, subKey);
+                return createPacketInfo(packet, subKey, expirationType);
             }
         }
     }
 
-    return createPacketInfo(packet, key);
+    return createPacketInfo(packet, key, expirationType);
 };
 
-const getSubkeysFingerprints = ({ subKeys = [] } = {}) => {
+export const getSubKeysFingerprints = ({ subKeys = [] } = {}) => {
     return subKeys.map((subkey) => subkey.getFingerprint());
 };
 
-const primaryUser = async (key, date) => {
+/**
+ * Get primary user.
+ * @param {Key} key
+ * @param {Date} [date]
+ * @returns {Promise<{Object}>}>}
+ */
+export const getPrimaryUser = async (key, date) => {
     const primary = await key.getPrimaryUser(date);
 
-    if (!primary) {
-        return null;
-    }
-
-    if (!primary.user) {
-        return null;
-    }
-
-    if (!primary.selfCertification) {
-        return null;
+    if (!primary || !primary.user || !primary.selfCertification) {
+        return;
     }
 
     const cert = primary.selfCertification;
@@ -56,31 +59,61 @@ const primaryUser = async (key, date) => {
     };
 };
 
-export default async function keyInfo(rawKey, email, expectEncrypted = true, date = serverTime()) {
+/**
+ * Get key info and perform validations
+ * @param {String} rawKey
+ * @param {String} [email]
+ * @param {String} [expirationType]
+ * @param {boolean} [expectEncrypted]
+ * @param {Date} [date]
+ * @returns {Promise<Object>}
+ */
+export const getKeyInfo = async ({
+    rawKey,
+    email,
+    expirationType = EXPIRATION_TYPE.ENCRYPT_SIGN,
+    expectEncrypted = true,
+    date = serverTime()
+}) => {
     const keys = await getKeys(rawKey);
+    const [key] = keys;
 
-    const algoInfo = keys[0].getAlgorithmInfo();
-    const mainFingerprint = keys[0].getFingerprint();
+    const created = key.getCreationTime();
+    const fingerprints = [key.getFingerprint(), ...getSubKeysFingerprints(key)];
+    const algorithmInfo = key.getAlgorithmInfo();
+
+    const [fingerprint] = fingerprints;
+    const { bits, curve, algorithm } = algorithmInfo;
+
+    const [expires, user, encryptionKey, signingKey] = await Promise.all([
+        getExpirationTime(key, expirationType),
+        getPrimaryUser(key, date),
+        key.getEncryptionKey(undefined, date),
+        key.getSigningKey(undefined, date)
+    ]);
+
+    const [encrypt, sign] = await Promise.all([
+        getPacketInfo(encryptionKey, key, EXPIRATION_TYPE.ENCRYPT),
+        getPacketInfo(signingKey, key, EXPIRATION_TYPE.SIGN)
+    ]);
 
     const obj = {
-        version: keys[0].primaryKey.version,
-        publicKeyArmored: keys[0].toPublic().armor(),
-        fingerprint: mainFingerprint, // FIXME: deprecated, use fingerprints instead
-        fingerprints: [mainFingerprint, ...getSubkeysFingerprints(keys[0])],
-        userIds: keys[0].getUserIds(),
-        user: await primaryUser(keys[0], date),
-        bitSize: algoInfo.bits || null,
-        curve: algoInfo.curve || null,
-        created: keys[0].getCreationTime(),
-        algorithm: openpgp.enums.publicKey[algoInfo.algorithm],
-        algorithmName: algoInfo.algorithm,
-        expires: await keys[0].getExpirationTime('encrypt_sign').catch(() => null),
-        encrypt: await packetInfo(await keys[0].getEncryptionKey(undefined, date), keys[0]),
-        sign: await packetInfo(await keys[0].getSigningKey(undefined, date), keys[0]),
-        decrypted: keys[0].isDecrypted(), // null if public key
-        revocationSignatures: keys[0].revocationSignatures,
-        validationError: null,
-        dateError: null
+        version: key.primaryKey.version,
+        userIds: key.getUserIds(),
+        decrypted: key.isDecrypted(),
+        publicKeyArmored: key.toPublic().armor(),
+        fingerprint, // FIXME: deprecated, use fingerprints instead
+        fingerprints,
+        user,
+        bitSize: bits,
+        curve,
+        created,
+        algorithm: openpgp.enums.publicKey[algorithm],
+        algorithmName: algorithm,
+        expires,
+        encrypt,
+        sign,
+        revocationSignatures: key.revocationSignatures
     };
 
     try {
@@ -95,10 +128,20 @@ export default async function keyInfo(rawKey, email, expectEncrypted = true, dat
         obj.dateError = err.message;
     }
 
-    const encryptCheck = obj.encrypt
-        ? openpgp.encrypt({ message: createMessage('test message'), publicKeys: keys, date })
-        : Promise.resolve();
-    await encryptCheck;
+    if (obj.encrypt) {
+        await openpgp.encrypt({
+            message: createMessage('test message'),
+            publicKeys: keys,
+            date
+        });
+    }
 
     return obj;
+};
+
+/**
+ * @deprecated
+ */
+export async function keyInfo(rawKey, email, expectEncrypted, date) {
+    return getKeyInfo({ rawKey, email, expectEncrypted, date });
 }

--- a/lib/key/utils.js
+++ b/lib/key/utils.js
@@ -1,5 +1,6 @@
 import { openpgp } from '../openpgp';
 import { serverTime } from '../serverTime';
+import { EXPIRATION_TYPE } from '../constants';
 
 // returns promise for generated RSA public and encrypted private keys
 export function generateKey({ passphrase, date = serverTime(), ...rest }) {
@@ -41,10 +42,10 @@ export async function getKeys(rawKeys = '') {
     return keys.keys;
 }
 
-export async function isExpiredKey(key) {
-    const time = await key.getExpirationTime('encrypt_sign');
-    const timeServer = +serverTime();
-    return !(key.getCreationTime() <= timeServer && timeServer < time) || key.revocationSignatures.length > 0;
+export async function isExpiredKey(key, expirationType = EXPIRATION_TYPE.ENCRYPT_SIGN, date = serverTime()) {
+    const expirationTime = await key.getExpirationTime(expirationType);
+    const dateTime = +date;
+    return !(key.getCreationTime() <= dateTime && dateTime < expirationTime) || key.revocationSignatures.length > 0;
 }
 
 export async function compressKey(armoredKey) {

--- a/lib/pmcrypto.js
+++ b/lib/pmcrypto.js
@@ -64,9 +64,11 @@ export {
 
 export { default as MailParser } from './message/mailparser';
 
-export { default as keyInfo } from './key/info';
+export { keyInfo, getKeyInfo, getSubKeysFingerprints, getPrimaryUser } from './key/info';
 
 export { keyCheck } from './key/check';
+
+export { EXPIRATION_TYPE } from './constants';
 
 export const config = { debug: true };
 

--- a/test/key/info.data.js
+++ b/test/key/info.data.js
@@ -1,0 +1,96 @@
+export const publickey = `-----BEGIN PGP PUBLIC KEY BLOCK-----
+
+mI0EW5kE2gEEAN3QcfWzMQCniICMlLJg3LgHtobUyQbv+PO1wPbBTdTo5XddwMVO
+ef2QN+MNy4UXmRtjUoaWEvHzYQ1a8t10fUI0IyIjc2LhQDm2Wye6xXLrTxV0rWyp
+HjC5027fQjaNiyuBUCU9cG78mwZVFTw0lboWryHjqZuBoF2mPHopTaaxABEBAAG0
+JWV4cGlyYXRpb24gdGVzdCA8ZXhwaXJhdGlvbkB0ZXN0LmNvbT6IzgQTAQgAOBYh
+BPjBOFw5rULVXFVgVMkCMBoLuY3LBQJbmQTaAhsDBQsJCAcCBhUKCQgLAgQWAgMB
+Ah4BAheAAAoJEMkCMBoLuY3LwCQD/jCUZkJj8dTNmcn/3lGceL7IxGrh7oFEks9s
+bwWsMhi5i6KUxCoYnmm9kp/E1mLDE9JufXzJB+bvaCyCRPjS1hksoCTdcIVOuggc
+mtO5I+0ArW32mFHgLK1Dz6JrV8T4jiVkwpuD6YcTlL3O4ebGdCRyK4ICvHmSbRT5
+DX9A4XbpuI0EW5kE2gEEAJmcO5EPemO/04X1XFwktOhSFUg7iwGHjNmqv15PhloP
+NtjraL0K7rzYrC/cvaOBHQg8Va2MB11HkxUx50C1kBQf8K3BEhcFQwLpDjyocniu
+gFqUigNlQLP+xFkaYZfhxajPGzhUe+ja6GjcthYYV0F1QtooaQEy0C0cs7e5Cfot
+ABEBAAGIvAQYAQgAJgIbDBYhBPjBOFw5rULVXFVgVMkCMBoLuY3LBQJbmQhHBQkA
+AVTtAAoJEMkCMBoLuY3LWr8EANCDuRF0i9SSEo+eDeqsMGPcy56J1rJz6YBrr+sE
+hjz72pMy/LgTEucsc2Ag4SBO2ULxDj8A1o8M0wovqol57UgzkyzjqmsndyHgGP5+
+Zbrv9MFSY3S4PFCdvQRF4svp/nZ7TFmeX2BLYZH2KIE7m4wKIWsDy30mm33A+VbI
+EE1DuI0EW5kIbgEEAM38fxqrvdThdAwH9lSVR6Tb7JE4ASFY0j2EpDft1byBOiDm
+sSkdZfaMal4ItHbbqsNeKxDW6DFda0VS5zeamPl2/GD8X/lzyBYrV6iqqRKu4zql
+q3JSWRjkhcuJy48IwUQ0OR8cUrqK174cWylXY5mvjqJqxeI+dVxnvLC0lEdtABEB
+AAGIvAQYAQgAJhYhBPjBOFw5rULVXFVgVMkCMBoLuY3LBQJbmQhuAhsMBQkJZgGA
+AAoJEMkCMBoLuY3L6p8D/jwJkrNLrsBCDEv+7uIQWaXu9dn5sUY1hR2V8eIQo7yp
+r7Wg1nvgd7aRzevVrtpn/fowNXaB6pfX1bUl4sRbGAKnF1avn4tPBAAZ5eh67bhO
+JLdxTBJgqQoLePyHnb4LEPZItOUOMiHRBLUV8PSj/dxLEmYlmbPFOTnE62izRX4Q
+=dM0r
+-----END PGP PUBLIC KEY BLOCK-----`;
+
+export const creationkey = `-----BEGIN PGP PUBLIC KEY BLOCK-----
+Version: OpenPGP.js v3.0.5
+Comment: https://openpgpjs.org
+
+xsBNBFgsrPkBCAC4NTH8ew1ASUtqVRA3j+aolI5lMAmAER18fBIfwjd/IbtC
+XzYbi/+arYyIMzUXU3OZUTwifxV3PBu1FCq1ZxVvZyH2ZoliP5fwx39bv3sI
+Oo1ijtxUKgVXmu+o4N5y3dhAjO9UYFza5Wq8TjmNdPhHp/PEd1+qMK8W3cxm
+8Ly7du9zv3nQ1B5M5/uGoo4FyQxKdh4wX6lJnAjYI0g/kfj/zfzaPyjiRurB
+wuXrRYVcliUQy3OP/fera5VJOhGzb6/Kycth0dgBsMPsn8gx8VOHPiHDcXlv
+vwp6drbCXujReU+hZgPda/eqhafjQDbCAfs5ZJD/B4/6SF8IMQ+Z9gjVABEB
+AAHNNSJzaGFudGFyYW1AcHJvdG9ubWFpbC5jb20iIDxzaGFudGFyYW1AcHJv
+dG9ubWFpbC5jb20+wsB1BBABCAApBQJcaFwkBgsJBwgDAgkQbolVqMpNxdsE
+FQgKAgMWAgECGQECGwMCHgEAACzfB/9t+McxCVvVqUQblF1phnV8mKC9uPcU
+5yPEu07lRoJw3D3qusK25iDVwLGNS3Mx2G2ugHx6I/ik60LPDrOXgH44k90b
+LnyUIUGUFX61Rzn/Un637dw1o2+kOfQzN4SYce/rwPvF1efAnZiwSoVhy+Ks
+oV0MHA8QeP4woMhL6y014tJDrqHGXIk6KTMLp+CR/5gBlHaVihVIZsTgLj01
+y2J6NykjPVPy5CGFju457jaWcsxpaO308fQGUB5hhelJvKzUt9zpDL0Dyr2O
+sFVnKhDts5EoVE13Yp4BrZslvXR7PZqoaMNOXr8uSIWt6khe06aPH8cSBtCu
+MtsgAlmN08vxzsBNBFgsrPkBCADxmOuZvx1fMLxYr/08a/b3dZfncP1fA1PH
+66mkUo9kE5Zr5UOqqbbFaCQbuc54nE4pvAJgR6EaynrnzjfbX75/v0ElEhZq
+cAWEXgM+A+WwPD3KTpAcMDXd42lPkq1lHH7ExN4UsYfrqSF7T7GVMZpo30wC
+IOYBBbYAZUCiDmSjeLTE1iLx14G6GMxniL+3TvUWUSF5waabouzV6vYlBlok
+lby0vw7gyvexkPOQgG/u4lmsvNYRGl3UcVbecu2yS94RhBm/TG5kA+eaa8mc
+jBZsMZ2GcfDfMZZLrP/5KwjLJ9OTrV9yDM0D6F6sAVlBF4l0MyOXl8ov/Qc/
+bsdDA+J9ABEBAAHCwF8EGAEIABMFAlxoXCoJEG6JVajKTcXbAhsMAADltAf/
+TbsN49vres/68RKkg3C4wihCTzSujrFYOxeKJOZALynTvMTwpjKmYik7zaJT
++25WxK0P3IknYKpsUFlDtIBluvdz4McZLEH0ymNwsi3hsnEG3l2W18JdKdzl
+RLfkk/sT5Ay2LtjvPUmynkGvI3LFRkkqiA4buDiFOV/pqdV6RGIXEOcyMyPJ
+hufD30wViByeDdxpJsFOlVnw7D02WDNUHomhN2m8ogLJyFbfrG8/c54VmX6O
+J5Tj5Die5J5mSWCHbi9O0TBBgCysDxAr7blqK2xBO85q+Kp0809lPiS97iDq
+uokpJQHZjIvfQ5/9tx1946Tvo0RX0A26JfOO+J68XA==
+=MPBF
+-----END PGP PUBLIC KEY BLOCK-----`;
+
+export const keyInfoResult = {
+    version: 4,
+    userIds: ['expiration test <expiration@test.com>'],
+    decrypted: null,
+    publicKeyArmored:
+        '-----BEGIN PGP PUBLIC KEY BLOCK-----\r\nVersion: OpenPGP.js v4.4.7\r\nComment: https://openpgpjs.org\r\n\r\nxo0EW5kE2gEEAN3QcfWzMQCniICMlLJg3LgHtobUyQbv+PO1wPbBTdTo5Xdd\r\nwMVOef2QN+MNy4UXmRtjUoaWEvHzYQ1a8t10fUI0IyIjc2LhQDm2Wye6xXLr\r\nTxV0rWypHjC5027fQjaNiyuBUCU9cG78mwZVFTw0lboWryHjqZuBoF2mPHop\r\nTaaxABEBAAHNJWV4cGlyYXRpb24gdGVzdCA8ZXhwaXJhdGlvbkB0ZXN0LmNv\r\nbT7CwCUEEwEIADgWIQT4wThcOa1C1VxVYFTJAjAaC7mNywUCW5kE2gIbAwUL\r\nCQgHAgYVCgkICwIEFgIDAQIeAQIXgAAhCRDJAjAaC7mNyxYhBPjBOFw5rULV\r\nXFVgVMkCMBoLuY3LwCQD/jCUZkJj8dTNmcn/3lGceL7IxGrh7oFEks9sbwWs\r\nMhi5i6KUxCoYnmm9kp/E1mLDE9JufXzJB+bvaCyCRPjS1hksoCTdcIVOuggc\r\nmtO5I+0ArW32mFHgLK1Dz6JrV8T4jiVkwpuD6YcTlL3O4ebGdCRyK4ICvHmS\r\nbRT5DX9A4Xbpzo0EW5kE2gEEAJmcO5EPemO/04X1XFwktOhSFUg7iwGHjNmq\r\nv15PhloPNtjraL0K7rzYrC/cvaOBHQg8Va2MB11HkxUx50C1kBQf8K3BEhcF\r\nQwLpDjyocniugFqUigNlQLP+xFkaYZfhxajPGzhUe+ja6GjcthYYV0F1Qtoo\r\naQEy0C0cs7e5CfotABEBAAHCwBMEGAEIACYCGwwWIQT4wThcOa1C1VxVYFTJ\r\nAjAaC7mNywUCW5kIRwUJAAFU7QAhCRDJAjAaC7mNyxYhBPjBOFw5rULVXFVg\r\nVMkCMBoLuY3LWr8EANCDuRF0i9SSEo+eDeqsMGPcy56J1rJz6YBrr+sEhjz7\r\n2pMy/LgTEucsc2Ag4SBO2ULxDj8A1o8M0wovqol57UgzkyzjqmsndyHgGP5+\r\nZbrv9MFSY3S4PFCdvQRF4svp/nZ7TFmeX2BLYZH2KIE7m4wKIWsDy30mm33A\r\n+VbIEE1Dzo0EW5kIbgEEAM38fxqrvdThdAwH9lSVR6Tb7JE4ASFY0j2EpDft\r\n1byBOiDmsSkdZfaMal4ItHbbqsNeKxDW6DFda0VS5zeamPl2/GD8X/lzyBYr\r\nV6iqqRKu4zqlq3JSWRjkhcuJy48IwUQ0OR8cUrqK174cWylXY5mvjqJqxeI+\r\ndVxnvLC0lEdtABEBAAHCwBMEGAEIACYWIQT4wThcOa1C1VxVYFTJAjAaC7mN\r\nywUCW5kIbgIbDAUJCWYBgAAhCRDJAjAaC7mNyxYhBPjBOFw5rULVXFVgVMkC\r\nMBoLuY3L6p8D/jwJkrNLrsBCDEv+7uIQWaXu9dn5sUY1hR2V8eIQo7ypr7Wg\r\n1nvgd7aRzevVrtpn/fowNXaB6pfX1bUl4sRbGAKnF1avn4tPBAAZ5eh67bhO\r\nJLdxTBJgqQoLePyHnb4LEPZItOUOMiHRBLUV8PSj/dxLEmYlmbPFOTnE62iz\r\nRX4Q\r\n=qowb\r\n-----END PGP PUBLIC KEY BLOCK-----\r\n',
+    fingerprint: 'f8c1385c39ad42d55c556054c902301a0bb98dcb',
+    fingerprints: [
+        'f8c1385c39ad42d55c556054c902301a0bb98dcb',
+        'c6c4ab89263569e5f14ac7f315b0360097973829',
+        'b571ad827876ed1f9dc79f6442c9f9bf64ed98bb'
+    ],
+    user: {
+        userId: 'expiration test <expiration@test.com>',
+        symmetric: [9, 8, 7, 2],
+        hash: [10, 9, 8, 11, 2],
+        compression: [2, 3, 1]
+    },
+    bitSize: 1024,
+    created: new Date('2018-09-12T12:21:46.000Z'),
+    curve: undefined,
+    algorithm: 1,
+    algorithmName: 'rsa_encrypt_sign',
+    expires: new Date('2023-09-11T12:37:02.000Z'),
+    encrypt: {
+        algorithm: undefined,
+        expires: new Date('2023-09-11T12:37:02.000Z')
+    },
+    sign: {
+        algorithm: undefined,
+        expires: Infinity
+    },
+    revocationSignatures: [],
+    validationError: 'Preferred hash algorithm must be SHA256'
+};

--- a/test/key/info.spec.js
+++ b/test/key/info.spec.js
@@ -1,80 +1,28 @@
 import test from 'ava';
 import '../helper';
-import * as pmcrypto from '../../lib/pmcrypto';
+import { keyInfo } from '../../lib/pmcrypto';
 
-const publickey = `-----BEGIN PGP PUBLIC KEY BLOCK-----
+import { creationkey, publickey, keyInfoResult } from './info.data';
 
-mI0EW5kE2gEEAN3QcfWzMQCniICMlLJg3LgHtobUyQbv+PO1wPbBTdTo5XddwMVO
-ef2QN+MNy4UXmRtjUoaWEvHzYQ1a8t10fUI0IyIjc2LhQDm2Wye6xXLrTxV0rWyp
-HjC5027fQjaNiyuBUCU9cG78mwZVFTw0lboWryHjqZuBoF2mPHopTaaxABEBAAG0
-JWV4cGlyYXRpb24gdGVzdCA8ZXhwaXJhdGlvbkB0ZXN0LmNvbT6IzgQTAQgAOBYh
-BPjBOFw5rULVXFVgVMkCMBoLuY3LBQJbmQTaAhsDBQsJCAcCBhUKCQgLAgQWAgMB
-Ah4BAheAAAoJEMkCMBoLuY3LwCQD/jCUZkJj8dTNmcn/3lGceL7IxGrh7oFEks9s
-bwWsMhi5i6KUxCoYnmm9kp/E1mLDE9JufXzJB+bvaCyCRPjS1hksoCTdcIVOuggc
-mtO5I+0ArW32mFHgLK1Dz6JrV8T4jiVkwpuD6YcTlL3O4ebGdCRyK4ICvHmSbRT5
-DX9A4XbpuI0EW5kE2gEEAJmcO5EPemO/04X1XFwktOhSFUg7iwGHjNmqv15PhloP
-NtjraL0K7rzYrC/cvaOBHQg8Va2MB11HkxUx50C1kBQf8K3BEhcFQwLpDjyocniu
-gFqUigNlQLP+xFkaYZfhxajPGzhUe+ja6GjcthYYV0F1QtooaQEy0C0cs7e5Cfot
-ABEBAAGIvAQYAQgAJgIbDBYhBPjBOFw5rULVXFVgVMkCMBoLuY3LBQJbmQhHBQkA
-AVTtAAoJEMkCMBoLuY3LWr8EANCDuRF0i9SSEo+eDeqsMGPcy56J1rJz6YBrr+sE
-hjz72pMy/LgTEucsc2Ag4SBO2ULxDj8A1o8M0wovqol57UgzkyzjqmsndyHgGP5+
-Zbrv9MFSY3S4PFCdvQRF4svp/nZ7TFmeX2BLYZH2KIE7m4wKIWsDy30mm33A+VbI
-EE1DuI0EW5kIbgEEAM38fxqrvdThdAwH9lSVR6Tb7JE4ASFY0j2EpDft1byBOiDm
-sSkdZfaMal4ItHbbqsNeKxDW6DFda0VS5zeamPl2/GD8X/lzyBYrV6iqqRKu4zql
-q3JSWRjkhcuJy48IwUQ0OR8cUrqK174cWylXY5mvjqJqxeI+dVxnvLC0lEdtABEB
-AAGIvAQYAQgAJhYhBPjBOFw5rULVXFVgVMkCMBoLuY3LBQJbmQhuAhsMBQkJZgGA
-AAoJEMkCMBoLuY3L6p8D/jwJkrNLrsBCDEv+7uIQWaXu9dn5sUY1hR2V8eIQo7yp
-r7Wg1nvgd7aRzevVrtpn/fowNXaB6pfX1bUl4sRbGAKnF1avn4tPBAAZ5eh67bhO
-JLdxTBJgqQoLePyHnb4LEPZItOUOMiHRBLUV8PSj/dxLEmYlmbPFOTnE62izRX4Q
-=dM0r
------END PGP PUBLIC KEY BLOCK-----`;
+const trimVersion = (str) => {
+    return str.substr(str.indexOf('Comment: https'));
+};
 
-test('expiration test', async (t) => {
-    const { expires, dateError } = await pmcrypto.keyInfo(publickey);
-    t.is(expires.getTime(), new Date('2023-09-11T12:37:02.000Z').getTime());
-    t.is(dateError, null);
+test('keyInfo result', async (t) => {
+    const result = await keyInfo(publickey);
+    // Remove up to openpgp.js version
+    result.publicKeyArmored = trimVersion(result.publicKeyArmored);
+    keyInfoResult.publicKeyArmored = trimVersion(keyInfoResult.publicKeyArmored);
+    t.deepEqual(result, keyInfoResult);
 });
 
-const creationkey = `-----BEGIN PGP PUBLIC KEY BLOCK-----
-Version: OpenPGP.js v3.0.5
-Comment: https://openpgpjs.org
-
-xsBNBFgsrPkBCAC4NTH8ew1ASUtqVRA3j+aolI5lMAmAER18fBIfwjd/IbtC
-XzYbi/+arYyIMzUXU3OZUTwifxV3PBu1FCq1ZxVvZyH2ZoliP5fwx39bv3sI
-Oo1ijtxUKgVXmu+o4N5y3dhAjO9UYFza5Wq8TjmNdPhHp/PEd1+qMK8W3cxm
-8Ly7du9zv3nQ1B5M5/uGoo4FyQxKdh4wX6lJnAjYI0g/kfj/zfzaPyjiRurB
-wuXrRYVcliUQy3OP/fera5VJOhGzb6/Kycth0dgBsMPsn8gx8VOHPiHDcXlv
-vwp6drbCXujReU+hZgPda/eqhafjQDbCAfs5ZJD/B4/6SF8IMQ+Z9gjVABEB
-AAHNNSJzaGFudGFyYW1AcHJvdG9ubWFpbC5jb20iIDxzaGFudGFyYW1AcHJv
-dG9ubWFpbC5jb20+wsB1BBABCAApBQJcaFwkBgsJBwgDAgkQbolVqMpNxdsE
-FQgKAgMWAgECGQECGwMCHgEAACzfB/9t+McxCVvVqUQblF1phnV8mKC9uPcU
-5yPEu07lRoJw3D3qusK25iDVwLGNS3Mx2G2ugHx6I/ik60LPDrOXgH44k90b
-LnyUIUGUFX61Rzn/Un637dw1o2+kOfQzN4SYce/rwPvF1efAnZiwSoVhy+Ks
-oV0MHA8QeP4woMhL6y014tJDrqHGXIk6KTMLp+CR/5gBlHaVihVIZsTgLj01
-y2J6NykjPVPy5CGFju457jaWcsxpaO308fQGUB5hhelJvKzUt9zpDL0Dyr2O
-sFVnKhDts5EoVE13Yp4BrZslvXR7PZqoaMNOXr8uSIWt6khe06aPH8cSBtCu
-MtsgAlmN08vxzsBNBFgsrPkBCADxmOuZvx1fMLxYr/08a/b3dZfncP1fA1PH
-66mkUo9kE5Zr5UOqqbbFaCQbuc54nE4pvAJgR6EaynrnzjfbX75/v0ElEhZq
-cAWEXgM+A+WwPD3KTpAcMDXd42lPkq1lHH7ExN4UsYfrqSF7T7GVMZpo30wC
-IOYBBbYAZUCiDmSjeLTE1iLx14G6GMxniL+3TvUWUSF5waabouzV6vYlBlok
-lby0vw7gyvexkPOQgG/u4lmsvNYRGl3UcVbecu2yS94RhBm/TG5kA+eaa8mc
-jBZsMZ2GcfDfMZZLrP/5KwjLJ9OTrV9yDM0D6F6sAVlBF4l0MyOXl8ov/Qc/
-bsdDA+J9ABEBAAHCwF8EGAEIABMFAlxoXCoJEG6JVajKTcXbAhsMAADltAf/
-TbsN49vres/68RKkg3C4wihCTzSujrFYOxeKJOZALynTvMTwpjKmYik7zaJT
-+25WxK0P3IknYKpsUFlDtIBluvdz4McZLEH0ymNwsi3hsnEG3l2W18JdKdzl
-RLfkk/sT5Ay2LtjvPUmynkGvI3LFRkkqiA4buDiFOV/pqdV6RGIXEOcyMyPJ
-hufD30wViByeDdxpJsFOlVnw7D02WDNUHomhN2m8ogLJyFbfrG8/c54VmX6O
-J5Tj5Die5J5mSWCHbi9O0TBBgCysDxAr7blqK2xBO85q+Kp0809lPiS97iDq
-uokpJQHZjIvfQ5/9tx1946Tvo0RX0A26JfOO+J68XA==
-=MPBF
------END PGP PUBLIC KEY BLOCK-----`;
+test('expiration test', async (t) => {
+    const { expires, dateError } = await keyInfo(publickey);
+    t.is(expires.getTime(), new Date('2023-09-11T12:37:02.000Z').getTime());
+    t.is(dateError, undefined);
+});
 
 test('creation test', async (t) => {
-    const { dateError } = await pmcrypto.keyInfo(
-        creationkey,
-        undefined,
-        undefined,
-        new Date('2019-01-01T00:00:00.000Z')
-    );
+    const { dateError } = await keyInfo(creationkey, undefined, undefined, new Date('2019-01-01T00:00:00.000Z'));
     t.is(dateError, 'The self certifications are created with illegal times');
 });


### PR DESCRIPTION
Adds:
* getKeyInfo({ rawKey, email, expirationType, expectedEncrypted, date })

Deprecates:
* keyInfo -> replaced with `getKeyInfo`