### PR TITLE
Add date option to reformatKey

### DIFF
--- a/lib/key/utils.js
+++ b/lib/key/utils.js
@@ -11,9 +11,9 @@ export function generateSessionKey(algorithm) {
     return openpgp.crypto.generateSessionKey(algorithm);
 }
 
-export function reformatKey(privKey, email = '', passphrase = '') {
-    if (passphrase.length === 0) {
-        return Promise.reject(new Error('Missing private key passcode'));
+export function reformatKey({ privateKey, email = '', passphrase, date = serverTime() }) {
+    if (!passphrase) {
+        throw new Error('Missing private key passphrase');
     }
 
     const user = {
@@ -22,12 +22,13 @@ export function reformatKey(privKey, email = '', passphrase = '') {
     };
 
     const options = {
-        privateKey: privKey,
+        privateKey,
         userIds: [user],
-        passphrase
+        passphrase,
+        date
     };
 
-    return openpgp.reformatKey(options).then((reformattedKey) => reformattedKey.privateKeyArmored);
+    return openpgp.reformatKey(options);
 }
 
 export async function getKeys(rawKeys = '') {

--- a/lib/key/utils.js
+++ b/lib/key/utils.js
@@ -2,18 +2,22 @@ import { openpgp } from '../openpgp';
 import { serverTime } from '../serverTime';
 
 // returns promise for generated RSA public and encrypted private keys
-export function generateKey(options) {
-    options.date = typeof options.date === 'undefined' ? serverTime() : options.date;
-    return openpgp.generateKey(options);
+export function generateKey({ passphrase, date = serverTime(), ...rest }) {
+    if (!passphrase) {
+        throw new Error('passphrase required');
+    }
+    return openpgp.generateKey({ passphrase, date, ...rest });
 }
 
 export function generateSessionKey(algorithm) {
     return openpgp.crypto.generateSessionKey(algorithm);
 }
 
-export function reformatKey(options) {
-    options.date = typeof options.date === 'undefined' ? serverTime() : options.date;
-    return openpgp.reformatKey(options);
+export function reformatKey({ passphrase, date = serverTime(), ...rest }) {
+    if (!passphrase) {
+        throw new Error('passphrase required');
+    }
+    return openpgp.reformatKey({ passphrase, date, ...rest });
 }
 
 export async function getKeys(rawKeys = '') {

--- a/lib/key/utils.js
+++ b/lib/key/utils.js
@@ -11,23 +11,8 @@ export function generateSessionKey(algorithm) {
     return openpgp.crypto.generateSessionKey(algorithm);
 }
 
-export function reformatKey({ privateKey, email = '', passphrase, date = serverTime() }) {
-    if (!passphrase) {
-        throw new Error('Missing private key passphrase');
-    }
-
-    const user = {
-        name: email,
-        email
-    };
-
-    const options = {
-        privateKey,
-        userIds: [user],
-        passphrase,
-        date
-    };
-
+export function reformatKey(options) {
+    options.date = typeof options.date === 'undefined' ? serverTime() : options.date;
     return openpgp.reformatKey(options);
 }
 


### PR DESCRIPTION
@twiss do you know if the user object should be more like

```
{ name:'Phil Zimmermann', email:'phil@openpgp.org' 
```

Because currently it's using the email for the name
```
{ name: email, email }
```