### PR TITLE
catch signature verification errors produced by openpgp

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -144,6 +144,7 @@ export function decryptMIMEMessage(
     getAttachments: () => Promise<any>;
     getEncryptedSubject: () => Promise<string>;
     verify: () => Promise<number>;
+    errors: () => Promise<Error[] | undefined>
 };
 
 export interface EncryptOptionsPmcrypto extends Omit<EncryptOptions, 'message'> {

--- a/lib/message/decrypt.js
+++ b/lib/message/decrypt.js
@@ -88,7 +88,7 @@ export async function decryptMessageLegacy(options) {
 /**
  * Decrypts the mime message and parses the body and attachments in the right structure.
  * @param options
- * @return {Promise<{getBody: (function(): Promise<{body, mimetype}>), getAttachments: (function(): Promise<any>), getEncryptedSubject: (function(): Promise<any>), verify: (function(): Promise<any>), stop: stop}>}
+ * @return {Promise<{getBody: (function(): Promise<{body, mimetype}>), getAttachments: (function(): Promise<any>), getEncryptedSubject: (function(): Promise<any>), verify: (function(): Promise<any>), errors: (function(): Promise<any>), stop: stop}>}
  */
 export async function decryptMIMEMessage(options) {
     const { data: rawData, verified: embeddedVerified, errors } = await decryptMessageLegacy(options);

--- a/lib/message/decrypt.js
+++ b/lib/message/decrypt.js
@@ -12,7 +12,7 @@ export async function decryptMessage(options) {
 
     try {
         const result = await openpgp.decrypt(options);
-        const { data, filename, verified, signatures } = await handleVerificationResult(
+        const { data, filename, verified, signatures, errors } = await handleVerificationResult(
             result,
             publicKeys,
             options.date
@@ -22,7 +22,8 @@ export async function decryptMessage(options) {
             data,
             filename,
             verified,
-            signatures
+            signatures,
+            errors
         };
     } catch (err) {
         if (err.message === 'CFB decrypt: invalid key' && options.passwords && options.passwords.length) {
@@ -55,7 +56,7 @@ export async function decryptMessageLegacy(options) {
         message: await getMessage(oldEncRandomKey)
     };
 
-    const { data } = await decryptMessage(oldOptions);
+    const { data, errors } = await decryptMessage(oldOptions);
     const randomKey = binaryStringToArray(decodeUtf8Base64(data));
 
     if (randomKey.length === 0) {
@@ -64,7 +65,7 @@ export async function decryptMessageLegacy(options) {
 
     oldEncMessage = binaryStringToArray(decodeUtf8Base64(oldEncMessage));
 
-    const params = { signature: 0 };
+    const params = { signature: 0, errors };
 
     // OpenPGP CFB mode with resync (https://tools.ietf.org/html/rfc4880#section-13.9)
     const result = await openpgp.crypto.cfb.decrypt(
@@ -90,7 +91,7 @@ export async function decryptMessageLegacy(options) {
  * @return {Promise<{getBody: (function(): Promise<{body, mimetype}>), getAttachments: (function(): Promise<any>), getEncryptedSubject: (function(): Promise<any>), verify: (function(): Promise<any>), stop: stop}>}
  */
 export async function decryptMIMEMessage(options) {
-    const { data: rawData, verified: embeddedVerified } = await decryptMessageLegacy(options);
+    const { data: rawData, verified: embeddedVerified, errors } = await decryptMessageLegacy(options);
 
     const { body, mimetype, verified: pgpVerified, attachments, encryptedSubject } = await processMIME(
         options,
@@ -104,6 +105,7 @@ export async function decryptMIMEMessage(options) {
         getAttachments: () => Promise.resolve(attachments),
         getEncryptedSubject: () => Promise.resolve(encryptedSubject),
         verify: () => Promise.resolve(verified),
+        errors: () => Promise.resolve(errors),
         stop() {}
     };
 }

--- a/lib/message/utils.js
+++ b/lib/message/utils.js
@@ -123,8 +123,10 @@ export async function handleVerificationResult({ data, filename = 'msg.txt', sig
                 })
                 .then(({ data, signatures }) => ({
                     data,
-                    signatures: signatures.map(({ signature }) => signature),
-                    verified: signatures[0].valid ? SIGNED_AND_VALID : SIGNED_AND_INVALID
+                    // the variable signatures contain a single element here
+                    signatures: signatures[0].signature,
+                    verified: signatures[0].valid ? SIGNED_AND_VALID : SIGNED_AND_INVALID,
+                    error: signatures[0].error
                 }));
         });
         const verificationResults = await Promise.all(verificationPromises);
@@ -134,13 +136,17 @@ export async function handleVerificationResult({ data, filename = 'msg.txt', sig
                 if (acc.verified === SIGNED_AND_VALID) {
                     acc.signatures = acc.signatures.concat(result.signature);
                 }
+                if (acc.verified === SIGNED_AND_INVALID && result.error) {
+                    acc.errors = acc.errors.concat(result.error);
+                }
                 return acc;
             },
             {
                 data,
                 verified,
                 filename,
-                signatures
+                signatures,
+                errors: []
             }
         );
     }


### PR DESCRIPTION
In version 4.10, OpenPGP.js is rejecting some signature algorithms (most notably SHA1) with a custom message. We want to catch this message to display to the user in case an email with one of those invalid signatures is received.