### PR TITLE
Add sha256Fingerprints property to keyInfo() result

### DIFF
--- a/lib/key/info.js
+++ b/lib/key/info.js
@@ -1,4 +1,5 @@
 import { openpgp } from '../openpgp';
+import { arrayToHexString, SHA256 } from '../utils';
 import { dateChecks, keyCheck } from './check';
 import { getKeys } from './utils';
 import { serverTime } from '../serverTime';
@@ -30,6 +31,14 @@ const packetInfo = (packet, key) => {
 
 const getSubkeysFingerprints = ({ subKeys = [] } = {}) => {
     return subKeys.map((subkey) => subkey.getFingerprint());
+};
+
+const getSHA256Fingerprints = (key) => {
+    return Promise.all(
+        key.getKeys().map(async ({ keyPacket }) => {
+            return arrayToHexString(await SHA256(keyPacket.writeForHash(keyPacket.version)));
+        })
+    );
 };
 
 const primaryUser = async (key, date) => {
@@ -67,6 +76,7 @@ export default async function keyInfo(rawKey, email, expectEncrypted = true, dat
         publicKeyArmored: keys[0].toPublic().armor(),
         fingerprint: mainFingerprint, // FIXME: deprecated, use fingerprints instead
         fingerprints: [mainFingerprint, ...getSubkeysFingerprints(keys[0])],
+        sha256Fingerprints: await getSHA256Fingerprints(keys[0]),
         userIds: keys[0].getUserIds(),
         user: await primaryUser(keys[0], date),
         bitSize: algoInfo.bits || null,

--- a/test/key/info.spec.js
+++ b/test/key/info.spec.js
@@ -1,6 +1,27 @@
 import test from 'ava';
 import '../helper';
 import * as pmcrypto from '../../lib/pmcrypto';
+import { openpgp } from '../../lib/openpgp';
+
+test('sha256 fingerprints - v4 key', async (t) => {
+    const { publicKeyArmored } = await pmcrypto.generateKey({ userIds: [{}], passphrase: 'test' });
+    const { fingerprints, sha256Fingerprints } = await pmcrypto.keyInfo(publicKeyArmored);
+    t.is(sha256Fingerprints.length, fingerprints.length);
+    sha256Fingerprints.forEach((sha256Fingerprint, i) => {
+        t.not(sha256Fingerprint, fingerprints[i]);
+    });
+});
+
+test('sha256 fingerprints - v5 key', async (t) => {
+    openpgp.config.v5_keys = !openpgp.config.v5_keys;
+    const { publicKeyArmored } = await pmcrypto.generateKey({ userIds: [{}], passphrase: 'test' });
+    const { fingerprints, sha256Fingerprints } = await pmcrypto.keyInfo(publicKeyArmored);
+    t.is(sha256Fingerprints.length, fingerprints.length);
+    sha256Fingerprints.forEach((sha256Fingerprint, i) => {
+        t.is(sha256Fingerprint, fingerprints[i]);
+    });
+    openpgp.config.v5_keys = !openpgp.config.v5_keys;
+});
 
 const publickey = `-----BEGIN PGP PUBLIC KEY BLOCK-----
 


### PR DESCRIPTION
These `sha256Fingerprints` are similar to the `fingerprints`, but always use SHA-256 as the hash function (for both v4 and v5 keys) and are thus more secure for verifying keys.