### PR TITLE
Update decryptMessageLegacy response type

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -27,7 +27,7 @@ export enum SIGNATURE_TYPES {
 
 // type defined in OpenPGP is not complete
 export interface OpenPGPKey extends key.Key {
-    users?: ({ userId?: { userid?: string } })[];
+    users?: { userId?: { userid?: string } }[];
 }
 
 export type OpenPGPMessage = message.Message;
@@ -141,7 +141,9 @@ export function decryptMessage(
 ): Promise<DecryptResultPmcrypto & { data: Uint8Array | ReadableStream<Uint8Array> }>;
 export function decryptMessage(options: DecryptOptions): Promise<DecryptResultPmcrypto>;
 
-export function decryptMessageLegacy(options: DecryptLegacyOptions): Promise<DecryptResult>;
+export function decryptMessageLegacy(
+    options: DecryptLegacyOptions
+): Promise<DecryptResultPmcrypto | { data: string; signature: number; error: Error[] | undefined }>;
 
 export function decryptMIMEMessage(
     options: DecryptMimeOptions
@@ -150,7 +152,7 @@ export function decryptMIMEMessage(
     getAttachments: () => Promise<any>;
     getEncryptedSubject: () => Promise<string>;
     verify: () => Promise<number>;
-    errors: () => Promise<Error[] | undefined>
+    errors: () => Promise<Error[] | undefined>;
 };
 
 export interface EncryptOptionsPmcrypto extends Omit<EncryptOptions, 'message'> {


### PR DESCRIPTION
I couldn't makes old code typing match (`verified` property here https://github.com/ProtonMail/WebClient/blob/b2194e41d02cb7455f3228c73bd52573a24b0dff/src/app/message/factories/messageModel.js#L336), I discovered that `decryptMessageLegacy` was not good.

The result is not very elegant but it's what I end up looking at the code.