### PR TITLE
Fix genPublicEphemeralKey and genPrivateEphemeralKey for new OpenPGP.js

### DIFF
--- a/lib/key/utils.js
+++ b/lib/key/utils.js
@@ -128,7 +128,7 @@ export async function genPublicEphemeralKey({ Curve, Q, Fingerprint }) {
         S,
         openpgp.crypto.cipher[cipherAlgo].keySize,
         param,
-        curveObj,
+        false,
         false
     );
 
@@ -161,7 +161,7 @@ export async function genPrivateEphemeralKey({ Curve, d, V, Fingerprint }) {
         S,
         openpgp.crypto.cipher[cipherAlgo].keySize,
         param,
-        curveObj,
+        false,
         false
     );
 }


### PR DESCRIPTION
They would strip leading zeros in the shared key before the KDF, causing broken key exchange in 1/256 cases.

These functions are not currently used in production yet.

Broken in https://github.com/openpgpjs/openpgpjs/commit/e637e758916c10a47fbf6709a53099368a0cb9e3#diff-393134c8f16100b74cb2c2495b62fe8a.