### PR TITLE
Remove redundant key validation

### DIFF
--- a/lib/key/decrypt.js
+++ b/lib/key/decrypt.js
@@ -17,12 +17,6 @@ export async function decryptPrivateKey(privKey, privKeyPassCode) {
         throw new Error('Private key decryption failed');
     }
 
-    try {
-        await key.validate();
-    } catch (e) {
-        throw new Error('Public key parameter does not match private key parameter: ' + e.message);
-    }
-
     return key;
 }
 

--- a/lib/key/utils.js
+++ b/lib/key/utils.js
@@ -118,8 +118,7 @@ export async function genPublicEphemeralKey({ Curve, Q, Fingerprint }) {
     const param = openpgp.crypto.publicKey.elliptic.ecdh.buildEcdhParam(
         openpgp.enums.publicKey.ecdh,
         oid,
-        curveObj.cipher,
-        curveObj.hash,
+        new openpgp.KDFParams({ cipher: curveObj.cipher, hash: curveObj.hash }),
         Fingerprint
     );
 
@@ -151,8 +150,7 @@ export async function genPrivateEphemeralKey({ Curve, d, V, Fingerprint }) {
     const param = openpgp.crypto.publicKey.elliptic.ecdh.buildEcdhParam(
         openpgp.enums.publicKey.ecdh,
         oid,
-        curveObj.cipher,
-        curveObj.hash,
+        new openpgp.KDFParams({ cipher: curveObj.cipher, hash: curveObj.hash }),
         Fingerprint
     );
 

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "dependencies": {
     "@types/openpgp": "^4.4.8",
     "esm": "^3.0.84",
-    "openpgp": "~4.10.0"
+    "openpgp": "^4.10.7"
   },
   "engines": {
     "node": ">=10.15.1"

--- a/test/key/decryptMaliciousKey.spec.js
+++ b/test/key/decryptMaliciousKey.spec.js
@@ -87,11 +87,11 @@ BVwyGMu4Utoe7o2jTBfQiSuisOU5rQk=
 test('it fails to decrypt a key with mismatching private and public key parameters', async (t) => {
     const decryptedPrivateKey = decryptPrivateKey(testPrivateKeyMalicious, 'userpass');
     const error = await t.throwsAsync(decryptedPrivateKey);
-    t.regex(error.message, /Public key parameter does not match private key parameter/);
+    t.regex(error.message, /Key is invalid/);
 });
 
 test('it fails to decrypt a key with all GNU-dummy key packets', async (t) => {
     const decryptedPrivateKey = decryptPrivateKey(testPrivateKeyAllDummy, 'any password');
     const error = await t.throwsAsync(decryptedPrivateKey);
-    t.regex(error.message, /Missing private key parameters/);
+    t.regex(error.message, /Cannot validate an all-gnu-dummy key/);
 });


### PR DESCRIPTION
openpgpjs validates the key as part of `key.decrypt`, so we can remove some code.