### PR TITLE
 Fix #92 E-mail ending matching for keyCheck()

### DIFF
--- a/lib/key/check.js
+++ b/lib/key/check.js
@@ -15,7 +15,7 @@ export function keyCheck(info, email, expectEncrypted) {
             throw new Error('Missing or too many UserID packets');
         }
 
-        if ((info.user.userId + '').substr(-2 - email.length) !== '<' + email + '>') {
+        if ((info.user.userId + '').endsWith('<' + email + '>')) {
             throw new Error('UserID does not contain correct email address');
         }
     }

--- a/lib/key/check.js
+++ b/lib/key/check.js
@@ -15,7 +15,7 @@ export function keyCheck(info, email, expectEncrypted) {
             throw new Error('Missing or too many UserID packets');
         }
 
-        if (!new RegExp('<' + email + '>$').test(info.user.userId)) {
+        if (!(info.user.userId + '').endsWith('<' + email + '>')) {
             throw new Error('UserID does not contain correct email address');
         }
     }

--- a/lib/key/check.js
+++ b/lib/key/check.js
@@ -15,7 +15,7 @@ export function keyCheck(info, email, expectEncrypted) {
             throw new Error('Missing or too many UserID packets');
         }
 
-        if (!(info.user.userId + '').endsWith('<' + email + '>')) {
+        if ((info.user.userId + '').substr(-2 - email.length) !== '<' + email + '>') {
             throw new Error('UserID does not contain correct email address');
         }
     }

--- a/lib/key/check.js
+++ b/lib/key/check.js
@@ -15,7 +15,7 @@ export function keyCheck(info, email, expectEncrypted) {
             throw new Error('Missing or too many UserID packets');
         }
 
-        if ((info.user.userId + '').endsWith('<' + email + '>')) {
+        if (!(info.user.userId + '').endsWith('<' + email + '>')) {
             throw new Error('UserID does not contain correct email address');
         }
     }


### PR DESCRIPTION
Previously: `keyCheck(info, 'jack.black@foo.com')` threw no error with `userId: 'Jacky Black <jackyblack@foo.com>'`
With this change it throw `UserID does not contain correct email address`

Fix #92