### PR TITLE
Allow decryption with RSA signing keys to get around old bug

### DIFF
--- a/lib/openpgp.js
+++ b/lib/openpgp.js
@@ -8,4 +8,10 @@ export const setInstance = (value) => {
 
 export const setConfig = (openpgp) => {
     openpgp.config.s2k_iteration_count_byte = 96;
+    /**
+     * This option is needed because we have some old messages from 2015-2016
+     * that were encrypted using non-encryption RSA keys, due to an openpgpjs bug.
+     * Some time after implementing symmetric re-encryption we should be able to disable this
+     */
+    openpgp.config.allow_insecure_decryption_with_signing_keys = true;
 };

--- a/package.json
+++ b/package.json
@@ -44,9 +44,9 @@
   },
   "homepage": "https://github.com/ProtonMail/pmcrypto#readme",
   "dependencies": {
-    "@types/openpgp": "^4.4.8",
+    "@types/openpgp": "^4.4.12",
     "esm": "^3.0.84",
-    "openpgp": "^4.10.7"
+    "openpgp": "^4.10.8"
   },
   "engines": {
     "node": ">=10.15.1"

--- a/test/key/config.spec.js
+++ b/test/key/config.spec.js
@@ -3,6 +3,7 @@ import '../helper';
 import { openpgp } from '../../lib/openpgp';
 
 test('it sets the correct configuration on openpgp', async (t) => {
+    t.is(openpgp.config.allow_insecure_decryption_with_signing_keys, true);
     t.is(openpgp.config.s2k_iteration_count_byte, 96);
     t.is(openpgp.config.integrity_protect, true);
     t.is(openpgp.config.use_native, true);


### PR DESCRIPTION
Workaround for old openpgpjs bug, see https://github.com/openpgpjs/openpgpjs/pull/1148.
This issue will be properly fixed by symmetric re-encryption.