### PR TITLE
Added support for encrypted detached signatures

### DIFF
--- a/lib/message/decrypt.js
+++ b/lib/message/decrypt.js
@@ -11,10 +11,10 @@ export async function decryptMessage(options) {
     options.date = typeof options.date === 'undefined' ? serverTime() : options.date;
 
     try {
-        // If encSignature exists, decrypt and use it
-        if (options.encSignature) {
+        // If encryptedSignature exists, decrypt and use it
+        if (options.encryptedSignature) {
             const decryptedSignature = await openpgp.decrypt({
-                message: options.encSignature,
+                message: options.encryptedSignature,
                 privateKeys: options.privateKeys,
                 format: 'binary'
             });

--- a/lib/message/decrypt.js
+++ b/lib/message/decrypt.js
@@ -11,6 +11,16 @@ export async function decryptMessage(options) {
     options.date = typeof options.date === 'undefined' ? serverTime() : options.date;
 
     try {
+        // If encSignature exists, decrypt and use it
+        if (options.encSignature) {
+            const decryptedSignature = await openpgp.decrypt({
+                message: options.encSignature,
+                privateKeys: options.privateKeys,
+                format: 'binary'
+            });
+            options.signature = await openpgp.signature.read(decryptedSignature.data);
+        }
+
         const result = await openpgp.decrypt(options);
         const { data, filename, verified, signatures, errors } = await handleVerificationResult(
             result,

--- a/lib/message/encrypt.js
+++ b/lib/message/encrypt.js
@@ -3,7 +3,7 @@ import { openpgp } from '../openpgp';
 import { serverTime } from '../serverTime';
 import { createMessage } from './utils';
 
-export default function encryptMessage(options) {
+export default async function encryptMessage(options) {
     if (typeof options.data === 'string') {
         options.message = createMessage(openpgp.util.removeTrailingSpaces(options.data), options.filename);
     }
@@ -15,5 +15,24 @@ export default function encryptMessage(options) {
     options.date = typeof options.date === 'undefined' ? serverTime() : options.date;
     options.compression = options.compression ? openpgp.enums.compression.zlib : undefined;
 
-    return openpgp.encrypt(options);
+    if (options.detached) {
+        // Create detached signature of message
+        const signature = await options.message.signDetached(options.privateKeys);
+
+        // Encrypt message without signing it (thus no need to change .detached)
+        options.privateKeys = [];
+        const ciphertext = await openpgp.encrypt(options);
+
+        // Encrypt signature and add it to the final package
+        options.message = createMessage(signature.packets.write(), options.filename);
+        const encSignature = await openpgp.encrypt(options);
+        ciphertext.encSignature = encSignature.data;
+
+        // Add plain signature for backward compatibility
+        ciphertext.signature = signature.armor();
+
+        return ciphertext;
+    } else {
+        return openpgp.encrypt(options);
+    }
 }

--- a/lib/message/encrypt.js
+++ b/lib/message/encrypt.js
@@ -21,17 +21,17 @@ export default async function encryptMessage(options) {
 
         // Encrypt message without signing it (thus no need to change .detached)
         options.privateKeys = [];
-        const ciphertext = await openpgp.encrypt(options);
+        const result = await openpgp.encrypt(options);
 
-        // Encrypt signature and add it to the final package
+        // Encrypt signature and add it to the final result
         options.message = createMessage(signature.packets.write(), options.filename);
-        const encSignature = await openpgp.encrypt(options);
-        ciphertext.encSignature = encSignature.data;
+        const encryptedSignature = await openpgp.encrypt(options);
+        result.encryptedSignature = options.armor ? encryptedSignature.data : encryptedSignature.message;
 
         // Add plain signature for backward compatibility
-        ciphertext.signature = signature.armor();
+        result.signature = options.armor ? signature.armor() : signature;
 
-        return ciphertext;
+        return result;
     } else {
         return openpgp.encrypt(options);
     }

--- a/lib/message/encrypt.js
+++ b/lib/message/encrypt.js
@@ -3,7 +3,7 @@ import { openpgp } from '../openpgp';
 import { serverTime } from '../serverTime';
 import { createMessage } from './utils';
 
-export default async function encryptMessage(options) {
+export default async function encryptMessage({ armor = true, ...options }) {
     if (typeof options.data === 'string') {
         options.message = createMessage(openpgp.util.removeTrailingSpaces(options.data), options.filename);
     }
@@ -19,17 +19,24 @@ export default async function encryptMessage(options) {
         // Create detached signature of message
         const signature = await options.message.signDetached(options.privateKeys);
 
-        // Encrypt message without signing it (thus no need to change .detached)
-        options.privateKeys = [];
-        const result = await openpgp.encrypt(options);
+        // Encrypt message without signing it
+        const result = await openpgp.encrypt({
+            ...options,
+            privateKeys: [],
+            armor
+        });
 
         // Encrypt signature and add it to the final result
-        options.message = createMessage(signature.packets.write(), options.filename);
-        const encryptedSignature = await openpgp.encrypt(options);
-        result.encryptedSignature = options.armor ? encryptedSignature.data : encryptedSignature.message;
+        const encryptedSignature = await openpgp.encrypt({
+            ...options,
+            message: createMessage(signature.packets.write()),
+            privateKeys: [],
+            armor
+        });
+        result.encryptedSignature = armor ? encryptedSignature.data : encryptedSignature.message;
 
         // Add plain signature for backward compatibility
-        result.signature = options.armor ? signature.armor() : signature;
+        result.signature = armor ? signature.armor() : signature;
 
         return result;
     } else {

--- a/test/message/encryptMessage.spec.js
+++ b/test/message/encryptMessage.spec.js
@@ -50,7 +50,7 @@ test('it can encrypt and decrypt a message with an unencrypted detached signatur
 
 test('it can encrypt and decrypt a message with an encrypted detached signature', async (t) => {
     const decryptedPrivateKey = await decryptPrivateKey(testPrivateKeyLegacy, '123');
-    const { data: encrypted, encSignature } = await encryptMessage({
+    const { data: encrypted, encryptedSignature } = await encryptMessage({
         message: createMessage('Hello world!'),
         publicKeys: [decryptedPrivateKey.toPublic()],
         privateKeys: [decryptedPrivateKey],
@@ -58,19 +58,10 @@ test('it can encrypt and decrypt a message with an encrypted detached signature'
     });
     const { data: decrypted, verified } = await decryptMessage({
         message: await getMessage(encrypted),
-        encSignature: await getMessage(encSignature),
+        encryptedSignature: await getMessage(encryptedSignature),
         publicKeys: [decryptedPrivateKey.toPublic()],
         privateKeys: [decryptedPrivateKey]
     });
     t.is(decrypted, 'Hello world!');
     t.is(verified, VERIFICATION_STATUS.SIGNED_AND_VALID);
-    /*
-    DO WE HAVE A USECASE FOR USING verifyMessage WITH AN ENCRYPTED SIGNATURE?
-    const { verified: verifiedAgain } = await verifyMessage({
-        message: createMessage('Hello world!'),
-        encSignature: await getMessage(encSignature),
-        publicKeys: [decryptedPrivateKey.toPublic()]
-    });
-    t.is(verifiedAgain, VERIFICATION_STATUS.SIGNED_AND_VALID);
-    */
 });

--- a/test/message/encryptMessage.spec.js
+++ b/test/message/encryptMessage.spec.js
@@ -24,7 +24,7 @@ test('it can encrypt and decrypt a message', async (t) => {
     t.is(verified, VERIFICATION_STATUS.SIGNED_AND_VALID);
 });
 
-test('it can encrypt and decrypt a message with a detached signature', async (t) => {
+test('it can encrypt and decrypt a message with an unencrypted detached signature', async (t) => {
     const decryptedPrivateKey = await decryptPrivateKey(testPrivateKeyLegacy, '123');
     const { data: encrypted, signature } = await encryptMessage({
         message: createMessage('Hello world!'),
@@ -46,4 +46,31 @@ test('it can encrypt and decrypt a message with a detached signature', async (t)
         publicKeys: [decryptedPrivateKey.toPublic()]
     });
     t.is(verifiedAgain, VERIFICATION_STATUS.SIGNED_AND_VALID);
+});
+
+test('it can encrypt and decrypt a message with an encrypted detached signature', async (t) => {
+    const decryptedPrivateKey = await decryptPrivateKey(testPrivateKeyLegacy, '123');
+    const { data: encrypted, encSignature } = await encryptMessage({
+        message: createMessage('Hello world!'),
+        publicKeys: [decryptedPrivateKey.toPublic()],
+        privateKeys: [decryptedPrivateKey],
+        detached: true
+    });
+    const { data: decrypted, verified } = await decryptMessage({
+        message: await getMessage(encrypted),
+        encSignature: await getMessage(encSignature),
+        publicKeys: [decryptedPrivateKey.toPublic()],
+        privateKeys: [decryptedPrivateKey]
+    });
+    t.is(decrypted, 'Hello world!');
+    t.is(verified, VERIFICATION_STATUS.SIGNED_AND_VALID);
+    /*
+    DO WE HAVE A USECASE FOR USING verifyMessage WITH AN ENCRYPTED SIGNATURE?
+    const { verified: verifiedAgain } = await verifyMessage({
+        message: createMessage('Hello world!'),
+        encSignature: await getMessage(encSignature),
+        publicKeys: [decryptedPrivateKey.toPublic()]
+    });
+    t.is(verifiedAgain, VERIFICATION_STATUS.SIGNED_AND_VALID);
+    */
 });


### PR DESCRIPTION
When encrypting a message with detached signature, now the detached encrypted signature is available to use. If a detached encrypted signature exists, decryption decrypts and uses that one.