### PR TITLE
Add default value to publicKeys array when verifying mime signature

### DIFF
--- a/lib/message/processMIME.js
+++ b/lib/message/processMIME.js
@@ -20,7 +20,7 @@ export const parseMail = (data) => {
     });
 };
 
-const verifySignature = async ({ publicKeys, date }, data) => {
+const verifySignature = async ({ publicKeys = [], date }, data) => {
     const { headers } = await parseMail(data.split(/\r?\n\s*\r?\n/g)[0] + '\n\n');
     const contentType = headers['content-type'] || '';
     const [baseContentType] = contentType.split(';');


### PR DESCRIPTION
In the new beta of ProtonMail, we chose to split the steps of decryption and signature verification to save some time.

Because of this, we tried to pass `publicKeys: undefined` to `decryptMIMEMessage` but it fails because a default value is missing in `verifySignature`.