### PR TITLE
Add promise on the return type of decryptMIMEMessage

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -149,14 +149,14 @@ export function decryptMessageLegacy(options: DecryptLegacyOptions): Promise<Dec
 
 export function decryptMIMEMessage(
     options: DecryptMimeOptions
-): {
+): Promise<{
     getBody: () => Promise<{ body: string; mimetype: string } | undefined>;
     getAttachments: () => Promise<any>;
     getEncryptedSubject: () => Promise<string>;
     verify: () => Promise<number>;
     errors: () => Promise<Error[] | undefined>;
     signatures: OpenPGPSignature[];
-};
+}>;
 
 export interface EncryptOptionsPmcrypto extends Omit<EncryptOptions, 'message'> {
     data?: Uint8Array | string;


### PR DESCRIPTION
decryptMIMEMessage is async and returns a promis, this PR should align types to this.




Yet, I have hard time to understand the api design of decryptMIMEMessage.

It returns an object of async function, it would have sense if the function was indeed synchronous. But it's not, the function is async, wait for everything to be ready anyway.

Perhaps an historic choice? But feels strange today.