### PR TITLE
Return signature verification errors when verifying a message

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -135,6 +135,7 @@ export function decryptSessionKey(options: {
 export type DecryptResultPmcrypto = Omit<DecryptResult, 'signatures'> & {
     signatures: (OpenPGPSignature)[];
     verified: VERIFICATION_STATUS;
+    errors?: Error[];
 }
 
 export function decryptMessage(
@@ -252,6 +253,7 @@ export function unsafeSHA1(arg: Uint8Array): Promise<Uint8Array>;
 
 export interface VerifyMessageResult extends VerifyResult {
     verified: VERIFICATION_STATUS;
+    errors?: Error[];
 }
 export interface VerifyMessageOptions extends VerifyOptions {
     detached?: boolean;

--- a/lib/message/utils.js
+++ b/lib/message/utils.js
@@ -161,7 +161,7 @@ export function verifyMessage(options) {
     return openpgp
         .verify(options)
         .then((result) => handleVerificationResult(result, publicKeys, options.date))
-        .then(({ data, verified, signatures }) => ({ data, verified, signatures }))
+        .then(({ data, verified, signatures, errors }) => ({ data, verified, signatures, errors }))
         .catch((err) => {
             console.error(err);
             return Promise.reject(err);


### PR DESCRIPTION
Previously, we were only returning them on decryption