### PR TITLE
Fix handleVerificationResult when streaming and signature verification fails

### DIFF
--- a/lib/message/utils.js
+++ b/lib/message/utils.js
@@ -105,6 +105,7 @@ export async function handleVerificationResult({ data, filename = 'msg.txt', sig
     if (verified === SIGNED_AND_INVALID) {
         // enter extended text mode: some mail clients change spaces into nonbreaking spaces, we'll try to verify by normalizing this too.
         const verifiableSigs = sigs
+            .filter((sig) => sig && sig.packets)
             .filter(({ valid }) => valid !== null)
             .map(({ signature }) => signature)
             .filter(isCanonicalTextSignature);


### PR DESCRIPTION
Avoid firing errors when signatures are undefined or have no packets field in handleVerificationResult