### PR TITLE
Set creation time of generated keys 1 minute in the past

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -10,3 +10,5 @@ export const SIGNATURE_TYPES = {
 };
 
 export const MAX_ENC_HEADER_LENGTH = 1024;
+
+export const DEFAULT_OFFSET = -86400000;

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -11,4 +11,4 @@ export const SIGNATURE_TYPES = {
 
 export const MAX_ENC_HEADER_LENGTH = 1024;
 
-export const DEFAULT_OFFSET = -86400000;
+export const DEFAULT_OFFSET = -60000;

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -11,7 +11,8 @@ import {
     UserID,
     cleartext,
     VerifyOptions,
-    VerifyResult
+    VerifyResult,
+    KeyOptions
 } from 'openpgp';
 
 export enum VERIFICATION_STATUS {
@@ -38,7 +39,12 @@ export interface SessionKey {
     algorithm: string;
 }
 
-export { generateKey } from 'openpgp';
+export interface GenerateKeyOptions extends KeyOptions {
+    offset?: number;
+}
+export function generateKey(
+    option: GenerateKeyOptions
+): Promise<{ key: key.Key; privateKeyArmored: string; publicKeyArmored: string; revocationCertificate: string }>;
 
 export interface ReformatKeyOptions {
     privateKey: OpenPGPKey;

--- a/lib/key/utils.js
+++ b/lib/key/utils.js
@@ -1,12 +1,14 @@
 import { openpgp } from '../openpgp';
 import { serverTime } from '../serverTime';
+import { DEFAULT_OFFSET } from '../constants';
 
 // returns promise for generated RSA public and encrypted private keys
-export function generateKey({ passphrase, date = serverTime(), ...rest }) {
+export function generateKey({ passphrase, date = serverTime(), offset = DEFAULT_OFFSET, ...rest }) {
     if (!passphrase) {
         throw new Error('passphrase required');
     }
-    return openpgp.generateKey({ passphrase, date, ...rest });
+    const offsetDate = new Date(date.getTime() + offset);
+    return openpgp.generateKey({ passphrase, date: offsetDate, ...rest });
 }
 
 export function generateSessionKey(algorithm) {


### PR DESCRIPTION
Add an `offset` parameter to `generateKey`, which is a number of milliseconds which gets added to the current (server) time, defaulting to minus one minute, to help avoid race conditions from clock desync.