### PR TITLE
Fix `verifyMessage` return type definitions

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -264,10 +264,13 @@ export function SHA512(arg: Uint8Array): Promise<Uint8Array>;
 export function unsafeMD5(arg: Uint8Array): Promise<Uint8Array>;
 export function unsafeSHA1(arg: Uint8Array): Promise<Uint8Array>;
 
-export interface VerifyMessageResult extends VerifyResult {
+export interface VerifyMessageResult {
+    data: VerifyResult['data'];
+    signatures: OpenPGPSignature[];
     verified: VERIFICATION_STATUS;
     errors?: Error[];
 }
+
 export interface VerifyMessageOptions extends VerifyOptions {
     detached?: boolean;
 }


### PR DESCRIPTION
`verifyMessage` does not return the same `signatures` object as `openpgpjs.verify`, since `handleVerificationResult` extracts the `signature` field from each entry:

- https://github.com/ProtonMail/pmcrypto/blob/55021f777aa775c581feda90beae302dc0272b27/lib/message/utils.js#L164
- https://github.com/ProtonMail/pmcrypto/blob/55021f777aa775c581feda90beae302dc0272b27/lib/message/utils.js#L101