### PR TITLE
Include signature timestamp in `verifyMessage` result

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -265,7 +265,10 @@ export function unsafeMD5(arg: Uint8Array): Promise<Uint8Array>;
 export function unsafeSHA1(arg: Uint8Array): Promise<Uint8Array>;
 
 export interface VerifyMessageResult extends VerifyResult {
+    data: VerifyResult['data'];
     verified: VERIFICATION_STATUS;
+    signatures: OpenPGPSignature[];
+    signatureTimestamp: Date|null,
     errors?: Error[];
 }
 export interface VerifyMessageOptions extends VerifyOptions {

--- a/lib/message/utils.js
+++ b/lib/message/utils.js
@@ -99,7 +99,7 @@ export function signMessage(options) {
  *     filename: String,
  *     verified: constants.VERIFICATION_STATUS - message verification status,
  *     signatures: openpgp.signature.Signature[] - message signatures,
- *     signatureTimestamp: Date|null - creation date of any valid message signature, or null if all signatures are missing or invalid,
+ *     signatureTimestamp: Date|null - creation date of the first valid message signature, or null if all signatures are missing or invalid,
  *     errors: Error[]|undefined - verification errors if all signatures are invalid
  * }}
  */
@@ -122,7 +122,7 @@ export async function handleVerificationResult({ data, filename = 'msg.txt', sig
                 verificationStatus = SIGNED_AND_VALID;
 
                 const verifiedSigPacket = signature.packets.find((signaturePacket) => signaturePacket.verified);
-                if (verifiedSigPacket) {
+                if (verifiedSigPacket && !signatureTimestamp) {
                     signatureTimestamp = verifiedSigPacket.created;
                 }
             }
@@ -153,7 +153,7 @@ export async function handleVerificationResult({ data, filename = 'msg.txt', sig
  *     data: Uint8Array|string|ReadableStream|NodeStream - message data,
  *     verified: constants.VERIFICATION_STATUS - message verification status,
  *     signatures: openpgp.signature.Signature[] - message signatures,
- *     signatureTimestamp: Date|null - creation date of any valid message signature, or null if all signatures are missing or invalid,
+ *     signatureTimestamp: Date|null - creation date of the first valid message signature, or null if all signatures are missing or invalid,
  *     errors: Error[]|undefined - verification errors if all signatures are invalid
  * }
  */

--- a/lib/message/utils.js
+++ b/lib/message/utils.js
@@ -89,80 +89,92 @@ function isCanonicalTextSignature({ packets }) {
     return Object.values(packets).some(({ signatureType = false }) => signatureType === CANONICAL_TEXT);
 }
 
-export async function handleVerificationResult({ data, filename = 'msg.txt', signatures: sigs }, publicKeys, date) {
-    let verified = NOT_SIGNED;
+/**
+ * Extract information from the result of openpgp.verify
+ * @param {Object} verificationResult return value of openpgp.verify
+ * @param {Uint8Array|String|
+ *          ReadableStream|NodeStream} verificationResult.data message data
+ * @param {String} verificationResult.filename
+ * @param {Object[]} verificationResult.signatures verification information per signature: {
+ *           keyid: module:type/keyid,
+ *           verified: Promise<Boolean>,
+ *           signature: Promise<openpgp.signature.Signature>
+ *         }
+ * @returns {{
+ *     data: Uint8Array|string|ReadableStream|NodeStream - message data,
+ *     filename: String,
+ *     verified: constants.VERIFICATION_STATUS - message verification status,
+ *     signatures: openpgp.signature.Signature[] - message signatures,
+ *     signatureTimestamp: Date|null - creation date of any valid message signature, or null if all signatures are missing or invalid,
+ *     errors: Error[]|undefined - verification errors if all signatures are invalid
+ * }}
+ */
+export async function handleVerificationResult({ data, filename = 'msg.txt', signatures: sigsInfo }) {
     const signatures = [];
-    if (sigs && sigs.length) {
-        verified = SIGNED_AND_INVALID;
-        for (let i = 0; i < sigs.length; i++) {
-            if (await sigs[i].verified.catch(() => false)) {
-                verified = SIGNED_AND_VALID;
-            }
-            signatures.push(await sigs[i].signature);
-        }
-    }
+    const errors = [];
+    let verificationStatus = NOT_SIGNED;
+    let signatureTimestamp = null;
 
-    if (verified === SIGNED_AND_INVALID) {
-        // enter extended text mode: some mail clients change spaces into nonbreaking spaces, we'll try to verify by normalizing this too.
-        const verifiableSigs = sigs
-            .filter((sig) => sig && sig.packets)
-            .filter(({ valid }) => valid !== null)
-            .map(({ signature }) => signature)
-            .filter(isCanonicalTextSignature);
-        const text = typeof data === 'string' ? data : arrayToBinaryString(data);
-        const textMessage = createMessage(text.replace(/[\xa0]/g, ' '));
+    if (sigsInfo && sigsInfo.length) {
+        verificationStatus = SIGNED_AND_INVALID;
+        for (const { signature: signaturePromise, verified: verifiedPromise } of sigsInfo) {
+            const signature = await signaturePromise;
+            const verified = await verifiedPromise.catch((err) => {
+                errors.push(err);
+                return false;
+            });
+            if (verified) {
+                verificationStatus = SIGNED_AND_VALID;
 
-        const verificationPromises = verifiableSigs.map((signature) => {
-            return openpgp
-                .verify({
-                    message: textMessage,
-                    publicKeys,
-                    signature,
-                    date
-                })
-                .then(({ data, signatures }) => ({
-                    data,
-                    // the variable signatures contain a single element here
-                    signatures: signatures[0].signature,
-                    verified: signatures[0].valid ? SIGNED_AND_VALID : SIGNED_AND_INVALID,
-                    error: signatures[0].error
-                }));
-        });
-        const verificationResults = await Promise.all(verificationPromises);
-
-        return verificationResults.reduceRight(
-            (acc, result) => {
-                if (acc.verified === SIGNED_AND_INVALID && result.error) {
-                    acc.errors = acc.errors.concat(result.error);
+                const verifiedSigPacket = signature.packets.find((signaturePacket) => signaturePacket.verified);
+                if (verifiedSigPacket) {
+                    signatureTimestamp = verifiedSigPacket.created;
                 }
-                return acc;
-            },
-            {
-                data,
-                verified,
-                filename,
-                signatures,
-                errors: []
             }
-        );
+            signatures.push(signature);
+        }
     }
 
     return {
         data,
-        verified,
+        verified: verificationStatus,
         filename,
-        signatures
+        signatures,
+        signatureTimestamp,
+        errors: verificationStatus === SIGNED_AND_INVALID ? errors : undefined
     };
 }
 
+/**
+ * Verify a message
+ * @param  {Object}                      options input for openpgp.verify
+ * @param  {openpgp.Key|openpgp.Key[]}   options.publicKeys keys to verify signatures
+ * @param  {openpgp.cleartext.CleartextMessage|
+ *          openpgp.message.Message}     options.message message object with signatures
+ * @param  {openpgp.signature.Signature} [options.signature] detached signature
+ * @param  {Date}                        [options.date] date to use for verification instead of the server time
+ *
+ * @returns {Promise<Object>}  Verification result in the form: {
+ *     data: Uint8Array|string|ReadableStream|NodeStream - message data,
+ *     verified: constants.VERIFICATION_STATUS - message verification status,
+ *     signatures: openpgp.signature.Signature[] - message signatures,
+ *     signatureTimestamp: Date|null - creation date of any valid message signature, or null if all signatures are missing or invalid,
+ *     errors: Error[]|undefined - verification errors if all signatures are invalid
+ * }
+ */
 export function verifyMessage(options) {
-    const { publicKeys = [] } = options;
     options.date = typeof options.date === 'undefined' ? serverTime() : options.date;
 
     return openpgp
         .verify(options)
-        .then((result) => handleVerificationResult(result, publicKeys, options.date))
-        .then(({ data, verified, signatures, errors }) => ({ data, verified, signatures, errors }))
+        .then((result) => handleVerificationResult(result))
+        .then(({ data, verified, signatureTimestamp, signatures, errors }) => ({
+            data,
+            verified,
+            signatureTimestamp,
+            signatures,
+            errors
+        }))
         .catch((err) => {
             console.error(err);
             return Promise.reject(err);

--- a/lib/message/utils.js
+++ b/lib/message/utils.js
@@ -1,11 +1,9 @@
 /* eslint-disable no-prototype-builtins */
 import { openpgp } from '../openpgp';
-import { VERIFICATION_STATUS, SIGNATURE_TYPES } from '../constants';
-import { arrayToBinaryString } from '../utils';
+import { VERIFICATION_STATUS } from '../constants';
 import { serverTime } from '../serverTime';
 
 const { NOT_SIGNED, SIGNED_AND_VALID, SIGNED_AND_INVALID } = VERIFICATION_STATUS;
-const { CANONICAL_TEXT } = SIGNATURE_TYPES;
 
 /**
  * Prepare message
@@ -85,10 +83,6 @@ export function signMessage(options) {
     });
 }
 
-function isCanonicalTextSignature({ packets }) {
-    return Object.values(packets).some(({ signatureType = false }) => signatureType === CANONICAL_TEXT);
-}
-
 /**
  * Extract information from the result of openpgp.verify
  * @param {Object} verificationResult return value of openpgp.verify
@@ -117,7 +111,8 @@ export async function handleVerificationResult({ data, filename = 'msg.txt', sig
 
     if (sigsInfo && sigsInfo.length) {
         verificationStatus = SIGNED_AND_INVALID;
-        for (const { signature: signaturePromise, verified: verifiedPromise } of sigsInfo) {
+        for (let i = 0; i < sigsInfo.length; i++) {
+            const { signature: signaturePromise, verified: verifiedPromise } = sigsInfo[i];
             const signature = await signaturePromise;
             const verified = await verifiedPromise.catch((err) => {
                 errors.push(err);

--- a/test/message/util.spec.js
+++ b/test/message/util.spec.js
@@ -54,7 +54,7 @@ test('it does not verify a message given wrong public key', async (t) => {
     const { verified, signatureTimestamp, signatures, errors } = await verifyMessage({
         message: createMessage('hello world'),
         signature: await openpgp.signature.readArmored(detachedSignatureFromTwoKeys),
-        publicKeys: [wrongPublicKey] // the second public key is missing, expect only one signature to be verified
+        publicKeys: [wrongPublicKey]
     });
     t.is(verified, VERIFICATION_STATUS.SIGNED_AND_INVALID);
     t.is(signatures.length, 2);

--- a/test/message/util.spec.js
+++ b/test/message/util.spec.js
@@ -8,45 +8,81 @@ import { createMessage } from '../../lib';
 
 const detachedSignatureFromTwoKeys = `-----BEGIN PGP SIGNATURE-----
 
-wnUEARYKAAYFAmCCm2wAIQkQ2WdF8CsF19UWIQQ1dEimEZorFsTlaU3ZZ0Xw
-KwXX1aQtAQDItpxggXie0/j68KSun/N+4v27j85NU541xATv0TV/SQEAqvH8
-WKpeRk/iCFEaAcTPvxxeVrLLWqhrCiLWKFFCsAXCdQQBFgoABgUCYIKbbAAh
-CRArVw5Kj4m/khYhBA7Q0tE0M2e8lpmxVytXDkqPib+SpC0A/0ISxzab1VbK
-XqYY4hV6v78cc0/mMQHx6S8Ywdn5v79lAQDmc77Yo+lHN7o0X155r8KtUwIi
-hOOX3oYkoNh2f/G0Cg==
-=uoHK
+wnUEARYKAAYFAmCCo8gAIQkQyQtnL+EYbekWIQTopSabUSqDUEv/FMHJC2cv
+4Rht6VeGAP4mUJl+WYN9nLE57YByTh95OmcZmwfgz5Z4R570YqTVngD/VBym
+icc7YREcxij1gC6SSAe8kgKW6oVOWzxJ8HkOSQrCdQQBFgoABgUCYIK9vQAh
+CRCGHCX3YYW5NRYhBErDPc6OYkUaNQCLhoYcJfdhhbk1W1QBAPhrkAjimO22
+jh1V2A8pRCOs53Ig/AMAFbN37BaAIEVKAP0SVMTL6zTxYJcxWNPog7Bv5lM4
+Px4G+hZ2Kia//qlgBg==
+=0aeU
 -----END PGP SIGNATURE-----`;
 
 const armoredPublicKey = `-----BEGIN PGP PUBLIC KEY BLOCK-----
 
-xjMEYIGi4hYJKwYBBAHaRw8BAQdAyVB7z3DBQoPkR9R65EJrWOM5dZ4W3LaC
-qILzlmjG7j7NEHRlc3QgPHRlc3RAYS5pdD7CjAQQFgoAHQUCYIGi4gQLCQcI
-AxUICgQWAAIBAhkBAhsDAh4BACEJENlnRfArBdfVFiEENXRIphGaKxbE5WlN
-2WdF8CsF19UExAD/Tpei9iGj+bBFjU9y4AXFZ+vxhYZp/S0pXgPOLcN7+WYA
-/ihD0b+EOkATniqREyFHzmKSIsy2oNlwSbekNUhJ23oCzjgEYIGi4hIKKwYB
-BAGXVQEFAQEHQDH6hToBmVyfGJT48RKhPt/SGSuzlzFUFtZzqKN9Pw9uAwEI
-B8J4BBgWCAAJBQJggaLiAhsMACEJENlnRfArBdfVFiEENXRIphGaKxbE5WlN
-2WdF8CsF19XbJwEAygvtdQPSZ9XOK/hdbhTGyO2KUwcFTKhsFAYiB2V45MUA
-/iWbqJFGXCN2KnGAFldAFHYz4Bpusz1GaHqIcoI8YSsD
-=C9dE
+xjMEYIKjXxYJKwYBBAHaRw8BAQdAbmODPSLO5tOI0GxfV+x5bgiiFriCcH3t
+6lbJkS+OzKbNEHRlc3QgPHRlc3RAYS5pdD7CjAQQFgoAHQUCYIKjXwQLCQcI
+AxUICgQWAAIBAhkBAhsDAh4BACEJEMkLZy/hGG3pFiEE6KUmm1Eqg1BL/xTB
+yQtnL+EYbenOlAEAn7A7RXQJ9FUzhuiOHeKqczdslgOO5LFcng1LuSIWn1UB
+ANWHrxnH63jnFLE82mfhpRZ5FYJ1fEXA9+3v6at3ZE8IzjgEYIKjXxIKKwYB
+BAGXVQEFAQEHQA5moGr1AKlYvKI+JpyB6W640eXpQFNSiV6LBjuMteNbAwEI
+B8J2BBgWCAAJBQJggqNfAhsMACEJEMkLZy/hGG3pFiEE6KUmm1Eqg1BL/xTB
+yQtnL+EYben97QD4hf6DttxyczHGqxGbboatBZ3IufJgFm6r2xNf9d9lSAD3
+U12oHbxyYUhapbFFkSIBo7DWJqWvx3iUEPqzY6jIAA==
+=ZWrn
 -----END PGP PUBLIC KEY BLOCK-----`;
 
-test('it verifies a message with multiple signatures and returns the valid signature timestamp', async (t) => {
-    const publicKey = (await openpgp.key.readArmored(armoredPublicKey)).keys[0];
+const armoredPublicKey2 = `-----BEGIN PGP PUBLIC KEY BLOCK-----
+
+xjMEYIKjgxYJKwYBBAHaRw8BAQdARyd9iDlrlozcTG144XFIjWozyWLz0KQv
+fL4lqIrwM8XNEHRlc3QgPHRlc3RAYi5pdD7CjAQQFgoAHQUCYIKjgwQLCQcI
+AxUICgQWAAIBAhkBAhsDAh4BACEJEIYcJfdhhbk1FiEESsM9zo5iRRo1AIuG
+hhwl92GFuTVPRAD6A6//tK5pLPa1d7mgsoqyJ9BZyTAmnzxtbIgmOU9/TDcB
+AI4cGBfCOLzRPw6L0il5Rt78TX1jz4Dlzu6YixJcJ2AFzjgEYIKjgxIKKwYB
+BAGXVQEFAQEHQMjb0Q1FWvHzj0hyOiEN5ndChBDceUqxmQ0wOYDVqq8JAwEI
+B8J4BBgWCAAJBQJggqODAhsMACEJEIYcJfdhhbk1FiEESsM9zo5iRRo1AIuG
+hhwl92GFuTXz4AEAqn4L+ayYgphejF/ZTRIseHPK+t521CT6NZKoVaHnTWQA
+/0+kMEB5d+CH3Mb54cUganYHPLj5utO2PexEJc3xARIG
+=IEm4
+-----END PGP PUBLIC KEY BLOCK-----`;
+
+test('it verifies a message with multiple signatures', async (t) => {
+    const publicKey1 = (await openpgp.key.readArmored(armoredPublicKey)).keys[0];
+    const publicKey2 = (await openpgp.key.readArmored(armoredPublicKey2)).keys[0];
     const { data, verified, signatureTimestamp, signatures, errors } = await verifyMessage({
         message: createMessage('hello world'),
         signature: await openpgp.signature.readArmored(detachedSignatureFromTwoKeys),
-        publicKeys: [publicKey] // the second public key is missing, expect only one signature to be verified
+        publicKeys: [publicKey1, publicKey2]
     });
     t.deepEqual(data, openpgp.util.str_to_Uint8Array('hello world'));
     t.is(verified, VERIFICATION_STATUS.SIGNED_AND_VALID);
     t.is(signatures.length, 2);
     t.is(errors, undefined);
-    const verifiedSignature = signatures
-        .map(({ packets: [sigPacket] }) => sigPacket)
-        .find((sigPacket) => sigPacket.issuerKeyId.equals(publicKey.getKeyId()));
-    t.is(verifiedSignature.verified, true);
-    t.is(signatureTimestamp, verifiedSignature.created);
+    const signaturePackets = signatures.map(({ packets: [sigPacket] }) => sigPacket);
+    signaturePackets.forEach(({ verified }) => {
+        t.is(verified, true);
+    });
+    t.is(signatureTimestamp, signaturePackets[0].created);
+});
+
+test('it verifies a message with multiple signatures and returns the timestamp of the valid signature', async (t) => {
+    const publicKey1 = (await openpgp.key.readArmored(armoredPublicKey)).keys[0];
+    const publicKey2 = (await openpgp.key.readArmored(armoredPublicKey2)).keys[0];
+    const { data, verified, signatureTimestamp, signatures, errors } = await verifyMessage({
+        message: createMessage('hello world'),
+        signature: await openpgp.signature.readArmored(detachedSignatureFromTwoKeys),
+        publicKeys: [publicKey1] // the second public key is missing, expect only one signature to be verified
+    });
+    t.deepEqual(data, openpgp.util.str_to_Uint8Array('hello world'));
+    t.is(verified, VERIFICATION_STATUS.SIGNED_AND_VALID);
+    t.is(signatures.length, 2);
+    t.is(errors, undefined);
+    const signaturePackets = signatures.map(({ packets: [sigPacket] }) => sigPacket);
+    const validSignature = signaturePackets.find((sigPacket) => sigPacket.issuerKeyId.equals(publicKey1.getKeyId()));
+    const invalidSignature = signaturePackets.find((sigPacket) => sigPacket.issuerKeyId.equals(publicKey2.getKeyId()));
+    t.is(validSignature.verified, true);
+    t.is(signatureTimestamp, validSignature.created);
+    t.is(invalidSignature.verified, null);
+    t.not(signatureTimestamp, invalidSignature.created);
 });
 
 test('it does not verify a message given wrong public key', async (t) => {

--- a/test/message/util.spec.js
+++ b/test/message/util.spec.js
@@ -1,0 +1,96 @@
+import test from 'ava';
+import '../helper';
+
+import { openpgp } from '../../lib/openpgp';
+import { verifyMessage } from '../../lib/message/utils';
+import { VERIFICATION_STATUS } from '../../lib/constants';
+import { createMessage } from '../../lib';
+
+const detachedSignatureFromTwoKeys = `-----BEGIN PGP SIGNATURE-----
+
+wnUEARYKAAYFAmCCm2wAIQkQ2WdF8CsF19UWIQQ1dEimEZorFsTlaU3ZZ0Xw
+KwXX1aQtAQDItpxggXie0/j68KSun/N+4v27j85NU541xATv0TV/SQEAqvH8
+WKpeRk/iCFEaAcTPvxxeVrLLWqhrCiLWKFFCsAXCdQQBFgoABgUCYIKbbAAh
+CRArVw5Kj4m/khYhBA7Q0tE0M2e8lpmxVytXDkqPib+SpC0A/0ISxzab1VbK
+XqYY4hV6v78cc0/mMQHx6S8Ywdn5v79lAQDmc77Yo+lHN7o0X155r8KtUwIi
+hOOX3oYkoNh2f/G0Cg==
+=uoHK
+-----END PGP SIGNATURE-----`;
+
+const armoredPublicKey = `-----BEGIN PGP PUBLIC KEY BLOCK-----
+
+xjMEYIGi4hYJKwYBBAHaRw8BAQdAyVB7z3DBQoPkR9R65EJrWOM5dZ4W3LaC
+qILzlmjG7j7NEHRlc3QgPHRlc3RAYS5pdD7CjAQQFgoAHQUCYIGi4gQLCQcI
+AxUICgQWAAIBAhkBAhsDAh4BACEJENlnRfArBdfVFiEENXRIphGaKxbE5WlN
+2WdF8CsF19UExAD/Tpei9iGj+bBFjU9y4AXFZ+vxhYZp/S0pXgPOLcN7+WYA
+/ihD0b+EOkATniqREyFHzmKSIsy2oNlwSbekNUhJ23oCzjgEYIGi4hIKKwYB
+BAGXVQEFAQEHQDH6hToBmVyfGJT48RKhPt/SGSuzlzFUFtZzqKN9Pw9uAwEI
+B8J4BBgWCAAJBQJggaLiAhsMACEJENlnRfArBdfVFiEENXRIphGaKxbE5WlN
+2WdF8CsF19XbJwEAygvtdQPSZ9XOK/hdbhTGyO2KUwcFTKhsFAYiB2V45MUA
+/iWbqJFGXCN2KnGAFldAFHYz4Bpusz1GaHqIcoI8YSsD
+=C9dE
+-----END PGP PUBLIC KEY BLOCK-----`;
+
+test('it verifies a message with multiple signatures and returns the valid signature timestamp', async (t) => {
+    const publicKey = (await openpgp.key.readArmored(armoredPublicKey)).keys[0];
+    const { data, verified, signatureTimestamp, signatures, errors } = await verifyMessage({
+        message: createMessage('hello world'),
+        signature: await openpgp.signature.readArmored(detachedSignatureFromTwoKeys),
+        publicKeys: [publicKey] // the second public key is missing, expect only one signature to be verified
+    });
+    t.deepEqual(data, openpgp.util.str_to_Uint8Array('hello world'));
+    t.is(verified, VERIFICATION_STATUS.SIGNED_AND_VALID);
+    t.is(signatures.length, 2);
+    t.is(errors, undefined);
+    const verifiedSignature = signatures
+        .map(({ packets: [sigPacket] }) => sigPacket)
+        .find((sigPacket) => sigPacket.issuerKeyId.equals(publicKey.getKeyId()));
+    t.is(verifiedSignature.verified, true);
+    t.is(signatureTimestamp, verifiedSignature.created);
+});
+
+test('it does not verify a message given wrong public key', async (t) => {
+    const { key: wrongPublicKey } = await openpgp.generateKey({ userIds: [{ name: 'test', email: 'a@b.com' }] });
+    const { verified, signatureTimestamp, signatures, errors } = await verifyMessage({
+        message: createMessage('hello world'),
+        signature: await openpgp.signature.readArmored(detachedSignatureFromTwoKeys),
+        publicKeys: [wrongPublicKey] // the second public key is missing, expect only one signature to be verified
+    });
+    t.is(verified, VERIFICATION_STATUS.SIGNED_AND_INVALID);
+    t.is(signatures.length, 2);
+    t.is(errors.length, 0);
+    const verifiedSignatures = signatures
+        .map(({ packets: [sigPacket] }) => sigPacket)
+        .filter((sigPacket) => sigPacket.verified);
+    t.is(verifiedSignatures.length, 0);
+    t.is(signatureTimestamp, null);
+});
+
+test('it does not verify a message with corrupted signature', async (t) => {
+    const publicKey = (await openpgp.key.readArmored(armoredPublicKey)).keys[0];
+    const { verified, signatureTimestamp, signatures, errors } = await verifyMessage({
+        message: createMessage('corrupted'),
+        signature: await openpgp.signature.readArmored(detachedSignatureFromTwoKeys),
+        publicKeys: [publicKey]
+    });
+    t.is(verified, VERIFICATION_STATUS.SIGNED_AND_INVALID);
+    t.is(signatures.length, 2);
+    t.is(errors.length, 1);
+    const verifiedSignatures = signatures
+        .map(({ packets: [sigPacket] }) => sigPacket)
+        .filter((sigPacket) => sigPacket.verified);
+    t.is(verifiedSignatures.length, 0);
+    t.is(signatureTimestamp, null);
+});
+
+test('it detects missing signatures', async (t) => {
+    const publicKey = (await openpgp.key.readArmored(armoredPublicKey)).keys[0];
+    const { verified, signatureTimestamp, signatures, errors } = await verifyMessage({
+        message: createMessage('no signatures'),
+        publicKeys: [publicKey]
+    });
+    t.is(verified, VERIFICATION_STATUS.NOT_SIGNED);
+    t.is(signatures.length, 0);
+    t.is(errors, undefined);
+    t.is(signatureTimestamp, null);
+});


### PR DESCRIPTION
Changes:
- `verifyMessage` now returns a `signatureTimestamp` field containing the creation date of the first encountered valid signature. The field is `null` if the message is not signed, or if all signatures are invalid.
- fix/change the behaviour of `verifyMessage` on error: return errors if message verification fails
- superseeds #111 