### PR TITLE
Add typescript compilation to CI tests and fix `verifyMessage` return type

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -8,3 +8,4 @@ jobs:
        - run: npm i
        - run: npm run lint
        - run: npm test
+       - run: npm run test-type-definitions

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -264,7 +264,7 @@ export function SHA512(arg: Uint8Array): Promise<Uint8Array>;
 export function unsafeMD5(arg: Uint8Array): Promise<Uint8Array>;
 export function unsafeSHA1(arg: Uint8Array): Promise<Uint8Array>;
 
-export interface VerifyMessageResult extends VerifyResult {
+export interface VerifyMessageResult {
     data: VerifyResult['data'];
     verified: VERIFICATION_STATUS;
     signatures: OpenPGPSignature[];

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "test": "ava -v",
     "lint": "eslint $(find lib -type f -name '*.js')  --quiet",
     "pretty": "prettier --write $(find lib -type f -name '*.js')",
-    "postversion": "git push && git push --tags"
+    "postversion": "git push && git push --tags",
+    "test-type-definitions": "tsc lib/index.d.ts"
   },
   "husky": {
     "hooks": {
@@ -59,6 +60,7 @@
     "husky": "^1.1.0",
     "lint-staged": "^7.3.0",
     "mocha": "^5.2.0",
-    "prettier": "^1.14.3"
+    "prettier": "^1.14.3",
+    "typescript": "^4.2.4"
   }
 }


### PR DESCRIPTION
- Add TS compilation step to detect compilation errors in the CI.
- Fix `verifyMessage` return type.