### PR TITLE
Throw on server time updates too far off from local time

### DIFF
--- a/lib/serverTime.js
+++ b/lib/serverTime.js
@@ -5,7 +5,10 @@ export const serverTime = () => lastServerTime || new Date();
 export const updateServerTime = (serverDate) => {
     const localTime = new Date();
     const timeDifference = Math.abs(serverDate - localTime);
-    if (serverDate > lastServerTime && timeDifference < MILLISECONDS_24_HOURS) {
+    if (timeDifference > MILLISECONDS_24_HOURS) {
+        throw new Error('Server time is too far off from local time');
+    }
+    if (serverDate > lastServerTime) {
         lastServerTime = serverDate;
     }
     return lastServerTime;

--- a/lib/serverTime.js
+++ b/lib/serverTime.js
@@ -1,8 +1,11 @@
+const MILLISECONDS_24_HOURS = 24 * 3600 * 1000;
 let lastServerTime = null;
 
 export const serverTime = () => lastServerTime || new Date();
 export const updateServerTime = (serverDate) => {
-    if (serverDate > lastServerTime) {
+    const localTime = new Date();
+    const timeDifference = Math.abs(serverDate - localTime);
+    if (serverDate > lastServerTime && timeDifference < MILLISECONDS_24_HOURS) {
         lastServerTime = serverDate;
     }
     return lastServerTime;

--- a/test/serverTime.spec.js
+++ b/test/serverTime.spec.js
@@ -7,7 +7,7 @@ const oneHourAgo = new Date(Date.now() - MILLISECONDS_1_HOUR);
 const oneDayAgo = new Date(Date.now() - MILLISECONDS_1_HOUR * 25);
 const oneDayAhead = new Date(Date.now() + MILLISECONDS_1_HOUR * 25);
 
-test('it correctly updates the server time', async (t) => {
+test('it correctly updates the server time', (t) => {
     const currentServerTime = serverTime();
     const updatedServerTime = updateServerTime(oneHourAgo);
     t.not(currentServerTime, updatedServerTime);
@@ -15,15 +15,14 @@ test('it correctly updates the server time', async (t) => {
     t.is(updatedServerTime, serverTime());
 });
 
-test('it does not allow to set an older server time', async (t) => {
+test('it does not allow to set an older server time', (t) => {
     const currentTime = new Date();
     const updatedServerTime = updateServerTime(currentTime);
     t.is(currentTime, updatedServerTime);
     t.is(updateServerTime(oneHourAgo), currentTime);
 });
 
-test('it does not allow to set a server time too far from the local time', async (t) => {
-    const currentServerTime = serverTime();
-    t.is(updateServerTime(oneDayAgo), currentServerTime);
-    t.is(updateServerTime(oneDayAhead), currentServerTime);
+test('it does not allow to set a server time too far from the local time', (t) => {
+    t.throws(() => updateServerTime(oneDayAgo));
+    t.throws(() => updateServerTime(oneDayAhead));
 });

--- a/test/serverTime.spec.js
+++ b/test/serverTime.spec.js
@@ -1,0 +1,29 @@
+import test from 'ava';
+
+import { updateServerTime, serverTime } from '../lib';
+
+const MILLISECONDS_1_HOUR = 3600 * 1000;
+const oneHourAgo = new Date(Date.now() - MILLISECONDS_1_HOUR);
+const oneDayAgo = new Date(Date.now() - MILLISECONDS_1_HOUR * 25);
+const oneDayAhead = new Date(Date.now() + MILLISECONDS_1_HOUR * 25);
+
+test('it correctly updates the server time', async (t) => {
+    const currentServerTime = serverTime();
+    const updatedServerTime = updateServerTime(oneHourAgo);
+    t.not(currentServerTime, updatedServerTime);
+    t.is(updatedServerTime, oneHourAgo);
+    t.is(updatedServerTime, serverTime());
+});
+
+test('it does not allow to set an older server time', async (t) => {
+    const currentTime = new Date();
+    const updatedServerTime = updateServerTime(currentTime);
+    t.is(currentTime, updatedServerTime);
+    t.is(updateServerTime(oneHourAgo), currentTime);
+});
+
+test('it does not allow to set a server time too far from the local time', async (t) => {
+    const currentServerTime = serverTime();
+    t.is(updateServerTime(oneDayAgo), currentServerTime);
+    t.is(updateServerTime(oneDayAhead), currentServerTime);
+});


### PR DESCRIPTION
Throw error on server time updates that are not within 24 hours of the local time.

- [ ] should we throw on `null` serverTime, rather than defaulting to local time?