### PR TITLE
Add addSubkey utility function

### DIFF
--- a/lib/key/utils.js
+++ b/lib/key/utils.js
@@ -1,6 +1,8 @@
 import { openpgp } from '../openpgp';
 import { serverTime } from '../serverTime';
 import { DEFAULT_OFFSET } from '../constants';
+import { decryptPrivateKey } from './decrypt';
+import { encryptPrivateKey } from './encrypt';
 
 // returns promise for generated RSA public and encrypted private keys
 export function generateKey({ passphrase, date = serverTime(), offset = DEFAULT_OFFSET, ...rest }) {
@@ -164,4 +166,31 @@ export async function genPrivateEphemeralKey({ Curve, d, V, Fingerprint }) {
         false,
         false
     );
+}
+
+/**
+ * Add subkeys to an existing private key
+ *
+ * @param{Object<Options>}  Private key, passphrase, and additional options
+ * @param {String}  The armored private key
+ * @param {String}  The key passphrase if it is encrypted
+ * @param {Object<Array>}   Options for subkey generation
+ * @retruns {String} The updated key in armored format
+ * @async
+ */
+export async function addSubkey({ armoredKey, passphrase = null, options}) {
+    var key;
+    if (passphrase !== null) {
+        key = await decryptPrivateKey(armoredKey, passphrase);
+    } else {
+        const read = await openpgp.key.readArmored(armoredKey);
+        key = read.keys[0];
+    }
+
+    const newKey = await key.addSubkey(options);
+
+    if (passphrase !== null) {
+        return await encryptPrivateKey(newKey, passphrase);
+    }
+    return newKey.armor();
 }

--- a/lib/pmcrypto.js
+++ b/lib/pmcrypto.js
@@ -45,7 +45,8 @@ export {
     getMatchingKey,
     cloneKey,
     genPublicEphemeralKey,
-    genPrivateEphemeralKey
+    genPrivateEphemeralKey,
+    addSubkey
 } from './key/utils';
 
 export { decryptPrivateKey, decryptSessionKey } from './key/decrypt';


### PR DESCRIPTION
Add a utility function that can add subkeys to an existing PGP key.

It supports both encrypted and unencrypted private keys. The
specification of the subkeys is passed as-is to openpgp.