### PR TITLE
Fix `encryptMessage` to use the specified compression algorithm

### DIFF
--- a/lib/message/encrypt.js
+++ b/lib/message/encrypt.js
@@ -13,7 +13,6 @@ export default async function encryptMessage({ armor = true, ...options }) {
     }
 
     options.date = typeof options.date === 'undefined' ? serverTime() : options.date;
-    options.compression = options.compression ? openpgp.enums.compression.zlib : undefined;
 
     options.armor = armor;
 


### PR DESCRIPTION
According to the type declarations, `options.compression` should be an algorithm, but the library treated it as a flag. Thus, if a compression option was specified, `zlib` would always be used for compression.

This PR changes `encryptMessage` to treat `options.compression` as an algorithm specifier.
It is potentially a breaking change if the function was used as implemented, i.e. by passing a boolean to `options.compression`.