### PR TITLE
Use key creation time as default `date` in `reformatKey`

### DIFF
--- a/lib/key/utils.js
+++ b/lib/key/utils.js
@@ -20,11 +20,15 @@ export async function getPreferredAlgorithm(keys, date = serverTime()) {
     return openpgp.enums.read(openpgp.enums.symmetric, await openpgp.key.getPreferredAlgo('symmetric', keys, date));
 }
 
-export function reformatKey({ passphrase, date = serverTime(), ...rest }) {
+/**
+ * Reformat key to bind it to a new userID and generate the corresponding preferences.
+ * By default, the generated self-certification signatures are set to have creation time equal to the key creation time, to avoid rendering old messages unverifiable (see https://github.com/openpgpjs/openpgpjs/pull/1422).
+ */
+export function reformatKey({ privateKey, passphrase, date = privateKey.getCreationTime(), ...rest }) {
     if (!passphrase) {
         throw new Error('passphrase required');
     }
-    return openpgp.reformatKey({ passphrase, date, ...rest });
+    return openpgp.reformatKey({ privateKey, passphrase, date, ...rest });
 }
 
 export async function getKeys(rawKeys = '') {


### PR DESCRIPTION
To avoid rendering old messages unverifiable (see https://github.com/openpgpjs/openpgpjs/pull/1422).