### PR TITLE
Remove ESM and use karma for tests

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -11,10 +11,11 @@
     },
     "env": {
         "es6": true,
-        "node": true
+        "mocha": true
     },
     "plugins": [
-        "import"
+        "import",
+        "chai-friendly"
     ],
     "rules": {
         "arrow-parens": ["error", "always"],
@@ -31,7 +32,8 @@
         "no-param-reassign": "warn",
         "no-return-assign": "warn",
         "no-shadow": "off",
-        "no-unused-expressions": ["error", { "allowShortCircuit": true }],
+        "no-unused-expressions": "off",
+        "chai-friendly/no-unused-expressions": [ "error", { "allowShortCircuit": true } ],
         "arrow-body-style": "off",
         "space-before-function-paren": "off",
         "operator-linebreak": "off",

--- a/circle.yml
+++ b/circle.yml
@@ -1,11 +1,14 @@
-version: 2
+version: 2.1
+orbs:
+    browser-tools: circleci/browser-tools@1.2.3
 jobs:
-   build:
-     docker:
-       - image: cimg/node:lts
-     steps:
-       - checkout
-       - run: npm i
-       - run: npm run lint
-       - run: npm run test-type-definitions
-       - run: npm test
+    build:
+        docker:
+            - image: cimg/node:lts-browsers
+        steps:
+            - browser-tools/install-chrome
+            - checkout
+            - run: npm i
+            - run: npm run lint
+            - run: npm run test-type-definitions
+            - run: npm test

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,0 +1,61 @@
+module.exports = function(config) {
+    config.set({
+        // base path that will be used to resolve all patterns (eg. files, exclude)
+        basePath: '',
+
+        // frameworks to use
+        // available frameworks: https://www.npmjs.com/search?q=keywords:karma-adapter
+        frameworks: ['mocha', 'webpack'],
+
+        plugins: ['karma-mocha', 'karma-chrome-launcher', 'karma-webpack', 'karma-mocha-reporter'],
+
+        // list of files / patterns to load in the browser
+        files: [{ pattern: 'test/**/*.*', watched: false }],
+
+        // list of files / patterns to exclude
+        exclude: [],
+
+        // preprocess matching files before serving them to the browser
+        // available preprocessors: https://www.npmjs.com/search?q=keywords:karma-preprocessor
+        preprocessors: {
+            'test/**/*.*': 'webpack'
+        },
+
+        webpack: {
+            resolve: {
+                fallback: {
+                    stream: false,
+                    buffer: false
+                },
+                extensions: ['', '.js', '.ts']
+            },
+            module: {
+                rules: [{ test: /\.ts?$/, loader: 'ts-loader' }]
+            }
+        },
+
+        // available reporters: https://www.npmjs.com/search?q=keywords:karma-reporter
+        reporters: ['mocha'],
+
+        // web server port
+        port: 9876,
+
+        // enable / disable colors in the output (reporters and logs)
+        colors: true,
+
+        // level of logging
+        // possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
+        logLevel: config.LOG_INFO,
+
+        // enable / disable watching file and executing tests whenever any file changes
+        autoWatch: false,
+
+        // start these browsers
+        // available browser launchers: https://www.npmjs.com/search?q=keywords:karma-launcher
+        browsers: ['ChromeHeadless'],
+
+        // Concurrency level
+        // how many browser instances should be started simultaneously
+        concurrency: Infinity
+    });
+};

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,3 +1,1 @@
-require = require('esm')(module); // eslint-disable-line no-global-assign
-
-module.exports = require('./pmcrypto');
+export * from './pmcrypto';

--- a/package.json
+++ b/package.json
@@ -1,71 +1,67 @@
 {
-  "name": "pmcrypto",
-  "version": "6.6.0",
-  "description": "",
-  "main": "./lib/index.js",
-  "types": "./lib/index.d.ts",
-  "module": "./lib/pmcrypto.js",
-  "sideEffects": false,
-  "scripts": {
-    "test": "ava -v",
-    "lint": "eslint $(find lib -type f -name '*.js')  --quiet",
-    "pretty": "prettier --write $(find lib -type f -name '*.js')",
-    "postversion": "git push && git push --tags",
-    "test-type-definitions": "tsc lib/index.d.ts"
-  },
-  "husky": {
-    "hooks": {
-      "pre-commit": "lint-staged"
+    "name": "pmcrypto",
+    "version": "6.6.0",
+    "description": "",
+    "main": "./lib/index.js",
+    "types": "./lib/index.d.ts",
+    "module": "./lib/pmcrypto.js",
+    "sideEffects": false,
+    "scripts": {
+        "test": "karma start --single-run --browsers ChromeHeadless karma.conf.js",
+        "lint": "eslint $(find lib -type f -name '*.js')  --quiet",
+        "pretty": "prettier --write $(find lib -type f -name '*.js')",
+        "postversion": "git push && git push --tags",
+        "test-type-definitions": "tsc lib/index.d.ts"
+    },
+    "husky": {
+        "hooks": {
+            "pre-commit": "lint-staged"
+        }
+    },
+    "lint-staged": {
+        "*.js,*.ts": [
+            "prettier --write",
+            "git add"
+        ]
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/ProtonMail/pmcrypto.git"
+    },
+    "author": "ProtonMail",
+    "license": "MIT",
+    "bugs": {
+        "url": "https://github.com/ProtonMail/pmcrypto/issues"
+    },
+    "homepage": "https://github.com/ProtonMail/pmcrypto#readme",
+    "dependencies": {
+        "@types/openpgp": "^4.4.18",
+        "openpgp": "^4.10.8"
+    },
+    "engines": {
+        "node": ">=10.15.1"
+    },
+    "devDependencies": {
+        "@types/chai": "^4.3.0",
+        "@types/chai-as-promised": "^7.1.4",
+        "@types/mocha": "^9.0.0",
+        "@types/node": "^16.11.7",
+        "chai": "^4.3.4",
+        "chai-as-promised": "^7.1.1",
+        "eslint": "^6.3.0",
+        "eslint-config-airbnb-base": "^14.0.0",
+        "eslint-plugin-chai-friendly": "^0.7.2",
+        "eslint-plugin-import": "^2.18.2",
+        "husky": "^1.1.0",
+        "karma": "^6.3.9",
+        "karma-chrome-launcher": "^3.1.0",
+        "karma-mocha": "^2.0.1",
+        "karma-mocha-reporter": "^2.2.5",
+        "karma-webpack": "^5.0.0",
+        "lint-staged": "^11.2.6",
+        "mocha": "^9.1.3",
+        "prettier": "^1.14.3",
+        "ts-loader": "^9.2.6",
+        "typescript": "^4.2.4"
     }
-  },
-  "lint-staged": {
-    "*.js": [
-      "prettier --write",
-      "git add"
-    ]
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/ProtonMail/pmcrypto.git"
-  },
-  "author": "ProtonMail",
-  "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/ProtonMail/pmcrypto/issues"
-  },
-  "ava": {
-    "require": [
-      "esm"
-    ],
-    "files": [
-      "test/**/*.spec.ts"
-    ],
-    "typescript": {
-      "rewritePaths": {
-        "test/": "build/test/"
-      },
-      "compile": "tsc"
-    }
-  },
-  "homepage": "https://github.com/ProtonMail/pmcrypto#readme",
-  "dependencies": {
-    "@types/openpgp": "^4.4.18",
-    "esm": "^3.0.84",
-    "openpgp": "^4.10.8"
-  },
-  "engines": {
-    "node": ">=10.15.1"
-  },
-  "devDependencies": {
-    "@ava/typescript": "^2.0.0",
-    "ava": "^3.15.0",
-    "eslint": "^6.3.0",
-    "eslint-config-airbnb-base": "^14.0.0",
-    "eslint-plugin-import": "^2.18.2",
-    "husky": "^1.1.0",
-    "lint-staged": "^7.3.0",
-    "mocha": "^5.2.0",
-    "prettier": "^1.14.3",
-    "typescript": "^4.2.4"
-  }
 }

--- a/test/helper.ts
+++ b/test/helper.ts
@@ -1,3 +1,0 @@
-import { init } from '../lib/pmcrypto';
-
-init(require('openpgp'));

--- a/test/key/check.spec.ts
+++ b/test/key/check.spec.ts
@@ -1,5 +1,4 @@
-import test from 'ava';
-import '../helper';
+import { expect } from 'chai';
 import { checkKeyStrength } from '../../lib';
 import { openpgp } from '../../lib/openpgp';
 
@@ -58,20 +57,19 @@ m53MXUW1fnpBPuv9RWJDN+tLhm5FPJktpuElr6hcBg==
 =J9mf
 -----END PGP PUBLIC KEY BLOCK-----`;
 
-test('it warns on insecure primary key (RSA 512 bits)', async (t) => {
-    const key = (await openpgp.key.readArmored(rsa512BitsKey)).keys[0];
-    const error = t.throws(() => checkKeyStrength(key));
-    t.is(error.message, 'Keys shorter than 2047 bits are considered unsafe');
-});
+describe('key checks', () => {
+    it('it warns on insecure primary key (RSA 512 bits)', async () => {
+        const key = (await openpgp.key.readArmored(rsa512BitsKey)).keys[0];
+        expect(() => checkKeyStrength(key)).to.throw(/Keys shorter than 2047 bits are considered unsafe/);
+    });
 
-test('it warns on insecure subkey (ElGamal)', async (t) => {
-    const key = (await openpgp.key.readArmored(eddsaElGamalSubkey)).keys[0];
-    const error = t.throws(() => checkKeyStrength(key));
-    t.is(error.message, 'elgamal keys are considered unsafe');
-});
+    it('it warns on insecure subkey (ElGamal)', async () => {
+        const key = (await openpgp.key.readArmored(eddsaElGamalSubkey)).keys[0];
+        expect((() => checkKeyStrength(key))).to.throw(/elgamal keys are considered unsafe/);
+    });
 
-test('it does not warn on secure key (x25519)', async (t) => {
-    const key = (await openpgp.key.readArmored(ecc25519Key)).keys[0];
-    checkKeyStrength(key);
-    t.pass();
+    it('it does not warn on secure key (x25519)', async () => {
+        const key = (await openpgp.key.readArmored(ecc25519Key)).keys[0];
+        expect(() => checkKeyStrength(key)).to.not.throw();
+    });
 });

--- a/test/key/config.spec.ts
+++ b/test/key/config.spec.ts
@@ -1,11 +1,12 @@
-import test from 'ava';
-import '../helper';
+import { expect } from 'chai';
 import { openpgp } from '../../lib/openpgp';
 
-test('it sets the correct configuration on openpgp', async (t) => {
-    // @ts-ignore missing type declaration for config.allow_insecure_decryption_with_signing_keys
-    t.is(openpgp.config.allow_insecure_decryption_with_signing_keys, true);
-    t.is(openpgp.config.s2k_iteration_count_byte, 96);
-    t.is(openpgp.config.integrity_protect, true);
-    t.is(openpgp.config.use_native, true);
+describe('comfig', () => {
+    it('it sets the correct configuration on openpgp', () => {
+        // @ts-ignore missing type declaration for config.allow_insecure_decryption_with_signing_keys
+        expect(openpgp.config.allow_insecure_decryption_with_signing_keys).to.equal(true);
+        expect(openpgp.config.s2k_iteration_count_byte).to.equal(96);
+        expect(openpgp.config.integrity_protect).to.equal(true);
+        expect(openpgp.config.use_native).to.equal(true);
+    });
 });

--- a/test/key/decryptMaliciousKey.spec.ts
+++ b/test/key/decryptMaliciousKey.spec.ts
@@ -1,5 +1,4 @@
-import test from 'ava';
-import '../helper';
+import { expect } from 'chai';
 
 import { decryptPrivateKey } from '../../lib';
 
@@ -84,14 +83,14 @@ BVwyGMu4Utoe7o2jTBfQiSuisOU5rQk=
 =tZEz
 -----END PGP PRIVATE KEY BLOCK-----`;
 
-test('it fails to decrypt a key with mismatching private and public key parameters', async (t) => {
-    const decryptedPrivateKey = decryptPrivateKey(testPrivateKeyMalicious, 'userpass');
-    const error = await t.throwsAsync(decryptedPrivateKey);
-    t.regex(error.message, /Key is invalid/);
-});
+describe('malicious encrypted key detection', () => {
+    it('it fails to decrypt a key with mismatching private and public key parameters', async () => {
+        const decryptedPrivateKey = decryptPrivateKey(testPrivateKeyMalicious, 'userpass');
+        await expect(decryptedPrivateKey).to.be.rejectedWith(/Key is invalid/);
+    });
 
-test('it fails to decrypt a key with all GNU-dummy key packets', async (t) => {
-    const decryptedPrivateKey = decryptPrivateKey(testPrivateKeyAllDummy, 'any password');
-    const error = await t.throwsAsync(decryptedPrivateKey);
-    t.regex(error.message, /Cannot validate an all-gnu-dummy key/);
+    it('it fails to decrypt a key with all GNU-dummy key packets', async () => {
+        const decryptedPrivateKey = decryptPrivateKey(testPrivateKeyAllDummy, 'any password');
+        await expect(decryptedPrivateKey).to.be.rejectedWith(/Cannot validate an all-gnu-dummy key/);
+    });
 });

--- a/test/key/processMIME.spec.ts
+++ b/test/key/processMIME.spec.ts
@@ -1,5 +1,4 @@
-import test from 'ava';
-import '../helper';
+import { expect } from 'chai';
 
 import processMIME from '../../lib/message/processMIME';
 import { getKeys } from '../../lib';
@@ -13,46 +12,48 @@ import {
     key
 } from './processMIME.data';
 
-test('it can process multipart/signed mime messages and verify the signature', async (t) => {
-    const { body, verified } = await processMIME(
-        {
-            publicKeys: await getKeys(key)
-        },
-        multipartSignedMessage
-    );
-    t.is(verified, VERIFICATION_STATUS.SIGNED_AND_VALID);
-    t.is(body, multipartSignedMessageBody);
-});
+describe('processMIME', () => {
+    it('it can process multipart/signed mime messages and verify the signature', async () => {
+        const { body, verified } = await processMIME(
+            {
+                publicKeys: await getKeys(key)
+            },
+            multipartSignedMessage
+        );
+        expect(verified).to.equal(VERIFICATION_STATUS.SIGNED_AND_VALID);
+        expect(body).to.equal(multipartSignedMessageBody);
+    });
 
-test('it can process multipart/signed mime messages and verify the signature with extra parts at the end', async (t) => {
-    const { body, verified } = await processMIME(
-        {
-            publicKeys: await getKeys(key)
-        },
-        extraMultipartSignedMessage
-    );
-    t.is(verified, VERIFICATION_STATUS.SIGNED_AND_VALID);
-    t.is(body, 'hello');
-});
+    it('it can process multipart/signed mime messages and verify the signature with extra parts at the end', async () => {
+        const { body, verified } = await processMIME(
+            {
+                publicKeys: await getKeys(key)
+            },
+            extraMultipartSignedMessage
+        );
+        expect(verified).to.equal(VERIFICATION_STATUS.SIGNED_AND_VALID);
+        expect(body).to.equal('hello');
+    });
 
-test('it does not verify invalid messages', async (t) => {
-    const { verified, body } = await processMIME(
-        {
-            publicKeys: await getKeys(key)
-        },
-        invalidMultipartSignedMessage
-    );
-    t.is(verified, VERIFICATION_STATUS.NOT_SIGNED);
-    t.is(body, 'message with missing signature');
-});
+    it('it does not verify invalid messages', async () => {
+        const { verified, body } = await processMIME(
+            {
+                publicKeys: await getKeys(key)
+            },
+            invalidMultipartSignedMessage
+        );
+        expect(verified).to.equal(VERIFICATION_STATUS.NOT_SIGNED);
+        expect(body).to.equal('message with missing signature');
+    });
 
-test('it can parse messages with special characters in the boundary', async (t) => {
-    const { verified, body } = await processMIME(
-        {
-            publicKeys: await getKeys(key)
-        },
-        multiPartMessageWithSpecialCharacter
-    );
-    t.is(verified, VERIFICATION_STATUS.SIGNED_AND_VALID);
-    t.is(body, 'hello');
+    it('it can parse messages with special characters in the boundary', async () => {
+        const { verified, body } = await processMIME(
+            {
+                publicKeys: await getKeys(key)
+            },
+            multiPartMessageWithSpecialCharacter
+        );
+        expect(verified).to.equal(VERIFICATION_STATUS.SIGNED_AND_VALID);
+        expect(body).to.equal('hello');
+    });
 });

--- a/test/key/utils.spec.ts
+++ b/test/key/utils.spec.ts
@@ -1,5 +1,4 @@
-import test from 'ava';
-import '../helper';
+import { expect } from 'chai';
 import {
     binaryStringToArray,
     concatArrays,
@@ -7,7 +6,8 @@ import {
     encodeBase64,
     isExpiredKey,
     isRevokedKey,
-    reformatKey
+    reformatKey,
+    generateKey
 } from '../../lib';
 import {
     genPrivateEphemeralKey,
@@ -17,20 +17,21 @@ import {
 } from '../../lib/pmcrypto';
 import { openpgp } from '../../lib/openpgp';
 
-test('it can correctly encode base 64', async (t) => {
-    t.is(encodeBase64('foo'), 'Zm9v');
-});
+describe('key utils', () => {
+    it('it can correctly encode base 64', async () => {
+        expect(encodeBase64('foo')).to.equal('Zm9v');
+    });
 
-test('it can correctly decode base 64', async (t) => {
-    t.is(decodeBase64('Zm9v'), 'foo');
-});
+    it('it can correctly decode base 64', async () => {
+        expect(decodeBase64('Zm9v')).to.equal('foo');
+    });
 
-test('it can correctly concat arrays', async (t) => {
-    t.deepEqual(concatArrays([new Uint8Array(1), new Uint8Array(1)]), new Uint8Array(2));
-});
+    it('it can correctly concat arrays', async () => {
+        expect(concatArrays([new Uint8Array(1), new Uint8Array(1)])).to.deep.equal(new Uint8Array(2));
+    });
 
-test('it can correctly dearmor a message', async (t) => {
-    const x = await stripArmor(`
+    it('it can correctly dearmor a message', async () => {
+        const x = await stripArmor(`
 -----BEGIN PGP MESSAGE-----
 Version: GnuPG v2.0.19 (GNU/Linux)
 
@@ -38,187 +39,104 @@ jA0ECQMCpo7I8WqsebTJ0koBmm6/oqdHXJU9aPe+Po+nk/k4/PZrLmlXwz2lhqBg
 GAlY9rxVStLBrg0Hn+5gkhyHI9B85rM1BEYXQ8pP5CSFuTwbJ3O2s67dzQ==
 =VZ0/
 -----END PGP MESSAGE-----`);
-    t.deepEqual(
-        x,
-        new Uint8Array([
-            140,
-            13,
-            4,
-            9,
-            3,
-            2,
-            166,
-            142,
-            200,
-            241,
-            106,
-            172,
-            121,
-            180,
-            201,
-            210,
-            74,
-            1,
-            154,
-            110,
-            191,
-            162,
-            167,
-            71,
-            92,
-            149,
-            61,
-            104,
-            247,
-            190,
-            62,
-            143,
-            167,
-            147,
-            249,
-            56,
-            252,
-            246,
-            107,
-            46,
-            105,
-            87,
-            195,
-            61,
-            165,
-            134,
-            160,
-            96,
-            24,
-            9,
-            88,
-            246,
-            188,
-            85,
-            74,
-            210,
-            193,
-            174,
-            13,
-            7,
-            159,
-            238,
-            96,
-            146,
-            28,
-            135,
-            35,
-            208,
-            124,
-            230,
-            179,
-            53,
-            4,
-            70,
-            23,
-            67,
-            202,
-            79,
-            228,
-            36,
-            133,
-            185,
-            60,
-            27,
-            39,
-            115,
-            182,
-            179,
-            174,
-            221,
-            205
-        ])
-    );
-});
-
-test('it can correctly perform an ECDHE roundtrip', async (t) => {
-    const Q = binaryStringToArray(decodeBase64('QPOClKt3wRFh6I0D7ItvuRqQ9eIfJZfOcBK3qJ/J++oj'));
-    const d = binaryStringToArray(decodeBase64('TG4WP1jLiWurBSTrpTCeYrdpJUqFTVFg1PzD2/m26Jg='));
-    const Fingerprint = binaryStringToArray(decodeBase64('sbd0e0yF9dSX8+xH9VYDqGVK0Wk='));
-    const Curve = 'curve25519';
-
-    const { V, Z } = await genPublicEphemeralKey({ Curve, Q, Fingerprint });
-    const Zver = await genPrivateEphemeralKey({ Curve, V, d, Fingerprint });
-
-    t.deepEqual(Zver, Z);
-});
-
-// Test issue https://github.com/ProtonMail/pmcrypto/issues/92
-test('it can check userId against a given email', (t) => {
-    const info = {
-        version: 4,
-        userIds: ['jb'],
-        algorithmName: 'ecdsa',
-        encrypt: {},
-        revocationSignatures: [],
-        sign: {},
-        user: {
-            hash: [openpgp.enums.hash.sha256],
-            symmetric: [openpgp.enums.symmetric.aes256],
-            userId: 'Jacky Black <jackyblack@foo.com>'
-        }
-    };
-
-    t.is(info, keyCheck(info, 'jackyblack@foo.com'));
-
-    try {
-        keyCheck(info, 'jack.black@foo.com');
-        t.fail();
-    } catch (e: any) {
-        e.message === 'UserID does not contain correct email address' ? t.pass() : t.fail();
-    }
-});
-
-test('it reformats a key using the key creation time', async (t) => {
-    const date = new Date(0);
-    const { key } = await openpgp.generateKey({
-        userIds: [{ name: 'name', email: 'email@test.com' }],
-        date
+        expect(x).to.deep.equal(
+            new Uint8Array([
+                140, 13, 4, 9, 3, 2, 166, 142, 200, 241, 106, 172, 121, 180, 201,
+                210, 74, 1, 154, 110, 191, 162, 167, 71, 92, 149, 61, 104, 247,
+                190, 62, 143, 167, 147, 249, 56, 252, 246, 107, 46, 105, 87, 195,
+                61, 165, 134, 160, 96, 24, 9, 88, 246, 188, 85, 74, 210, 193, 174,
+                13, 7, 159, 238, 96, 146, 28, 135, 35, 208, 124, 230, 179, 53, 4,
+                70, 23, 67, 202, 79, 228, 36, 133, 185, 60, 27, 39, 115, 182, 179,
+                174, 221, 205
+            ])
+        );
     });
-    
-    const { key: reformattedKey } = await reformatKey({ privateKey: key, passphrase: '123', userIds: [{ name: 'reformatted', email: 'reformatteed@test.com' }] });
-    const primaryUser = await reformattedKey.getPrimaryUser();
-    t.is(primaryUser.user.userId.userid, 'reformatted <reformatteed@test.com>');
-    // @ts-ignore missing `created` field declaration in signature packet
-    t.deepEqual((await reformattedKey.getPrimaryUser()).selfCertification.created, date);
-});
 
-test('it can correctly detect an expired key', async (t) => {
-    const now = new Date();
-    // key expires in one second
-    const { key: expiringKey } = await openpgp.generateKey({
-        userIds: [{ name: 'name', email: 'email@test.com' }],
-        date: now,
-        keyExpirationTime: 1
+    it('it can correctly perform an ECDHE roundtrip', async () => {
+        const Q = binaryStringToArray(decodeBase64('QPOClKt3wRFh6I0D7ItvuRqQ9eIfJZfOcBK3qJ/J++oj'));
+        const d = binaryStringToArray(decodeBase64('TG4WP1jLiWurBSTrpTCeYrdpJUqFTVFg1PzD2/m26Jg='));
+        const Fingerprint = binaryStringToArray(decodeBase64('sbd0e0yF9dSX8+xH9VYDqGVK0Wk='));
+        const Curve = 'curve25519';
+
+        const { V, Z } = await genPublicEphemeralKey({ Curve, Q, Fingerprint });
+        const Zver = await genPrivateEphemeralKey({ Curve, V, d, Fingerprint });
+
+        expect(Zver).to.deep.equal(Z);
     });
-    t.is(await isExpiredKey(expiringKey, now), false);
-    t.is(await isExpiredKey(expiringKey, new Date(+now + 1000)), true);
-    t.is(await isExpiredKey(expiringKey, new Date(+now - 1000)), true);
 
-    const { key } = await openpgp.generateKey({ userIds: [{ name: 'name', email: 'email@test.com' }], date: now });
-    t.is(await isExpiredKey(key), false);
-    t.is(await isExpiredKey(key, new Date(+now - 1000)), true);
-});
+    // Test issue https://github.com/ProtonMail/pmcrypto/issues/92
+    it('it can check userId against a given email', () => {
+        const info = {
+            version: 4,
+            userIds: ['jb'],
+            algorithmName: 'ecdsa',
+            encrypt: {},
+            revocationSignatures: [],
+            sign: {},
+            user: {
+                hash: [openpgp.enums.hash.sha256],
+                symmetric: [openpgp.enums.symmetric.aes256],
+                userId: 'Jacky Black <jackyblack@foo.com>'
+            }
+        };
 
-test('it can correctly detect a revoked key', async (t) => {
-    const past = new Date(0);
-    const now = new Date();
+        expect(info).to.deep.equal(keyCheck(info, 'jackyblack@foo.com'));
 
-    const { key, revocationCertificate } = await openpgp.generateKey({
-        userIds: [{ name: 'name', email: 'email@test.com' }],
-        date: past
+        expect(
+            () => keyCheck(info, 'jack.black@foo.com')
+        ).to.throw(/UserID does not contain correct email address/);
     });
-    const { publicKey: revokedKey } = await openpgp.revokeKey({
-        // @ts-ignore wrong revokeKey input declaration
-        key,
-        revocationCertificate
+
+    it('it reformats a key using the key creation time', async () => {
+        const date = new Date(0);
+        const { key } = await openpgp.generateKey({
+            userIds: [{ name: 'name', email: 'email@it.com' }],
+            date
+        });
+
+        const { key: reformattedKey } = await reformatKey({
+            privateKey: key,
+            passphrase: '123',
+            userIds: [{ name: 'reformatted', email: 'reformatteed@it.com' }]
+        });
+        const primaryUser = await reformattedKey.getPrimaryUser();
+        expect(primaryUser.user.userId.userid).to.equal('reformatted <reformatteed@it.com>');
+        // @ts-ignore missing `created` field declaration in signature packet
+        expect((await reformattedKey.getPrimaryUser()).selfCertification.created).to.deep.equal(date);
     });
-    t.is(await isRevokedKey(revokedKey, past), true);
-    t.is(await isRevokedKey(revokedKey, now), true);
-    t.is(await isRevokedKey(key, now), false);
+
+    it('it can correctly detect an expired key', async () => {
+        const now = new Date();
+        // key expires in one second
+        const { key: expiringKey } = await openpgp.generateKey({
+            userIds: [{ name: 'name', email: 'email@it.com' }],
+            date: now,
+            keyExpirationTime: 1
+        });
+        expect(await isExpiredKey(expiringKey, now)).to.be.false;
+        expect(await isExpiredKey(expiringKey, new Date(+now + 1000))).to.be.true;
+        expect(await isExpiredKey(expiringKey, new Date(+now - 1000))).to.be.true;
+
+        const { key } = await openpgp.generateKey({ userIds: [{ name: 'name', email: 'email@test.com' }], date: now });
+        expect(await isExpiredKey(key)).to.be.false;
+        expect(await isExpiredKey(key, new Date(+now - 1000))).to.be.true;
+    });
+
+    it('it can correctly detect a revoked key', async () => {
+        const past = new Date(0);
+        const now = new Date();
+
+        const { key, revocationCertificate } = await openpgp.generateKey({
+            userIds: [{ name: 'name', email: 'email@it.com' }],
+            date: past
+        });
+        const { publicKey: revokedKey } = await openpgp.revokeKey({
+            // @ts-ignore wrong revokeKey input declaration
+            key,
+            revocationCertificate
+        });
+        expect(await isRevokedKey(revokedKey, past)).to.be.true;
+        expect(await isRevokedKey(revokedKey, now)).to.be.true;
+        expect(await isRevokedKey(key, now)).to.be.false;
+    });
 });

--- a/test/message/decryptMessageLegacy.spec.ts
+++ b/test/message/decryptMessageLegacy.spec.ts
@@ -1,27 +1,27 @@
-import test from 'ava';
-import '../helper';
-
+import { expect } from 'chai';
 import { decryptPrivateKey, decryptMessageLegacy } from '../../lib';
 import { testMessageEncryptedLegacy, testPrivateKeyLegacy, testMessageResult, testMessageEncryptedStandard } from './decryptMessageLegacy.data';
 
-test('it can decrypt a legacy message', async (t) => {
-    const decryptedPrivateKey = await decryptPrivateKey(testPrivateKeyLegacy, '123');
-    const { data } = await decryptMessageLegacy({
-        message: testMessageEncryptedLegacy,
-        privateKeys: [decryptedPrivateKey],
-        messageDate: new Date('2015-01-01')
-    });
-    t.is(data, testMessageResult);
-});
-
-test('it can decrypt a non-legacy armored message', async (t) => {
-    const decryptedPrivateKey = await decryptPrivateKey(testPrivateKeyLegacy, '123');
-
-    const { data } = await decryptMessageLegacy({
-        message: testMessageEncryptedStandard,
-        privateKeys: [decryptedPrivateKey],
-        messageDate: new Date('2015-01-01')
+describe('decryptMessageLegacy', () => {
+    it('it can decrypt a legacy message', async () => {
+        const decryptedPrivateKey = await decryptPrivateKey(testPrivateKeyLegacy, '123');
+        const { data } = await decryptMessageLegacy({
+            message: testMessageEncryptedLegacy,
+            privateKeys: [decryptedPrivateKey],
+            messageDate: new Date('2015-01-01')
+        });
+        expect(data).to.equal(testMessageResult);
     });
 
-    t.is(data, testMessageResult);
+    it('it can decrypt a non-legacy armored message', async () => {
+        const decryptedPrivateKey = await decryptPrivateKey(testPrivateKeyLegacy, '123');
+
+        const { data } = await decryptMessageLegacy({
+            message: testMessageEncryptedStandard,
+            privateKeys: [decryptedPrivateKey],
+            messageDate: new Date('2015-01-01')
+        });
+
+        expect(data).to.equal(testMessageResult);
+    });
 });

--- a/test/message/encryptMessage.spec.ts
+++ b/test/message/encryptMessage.spec.ts
@@ -1,5 +1,4 @@
-import test from 'ava';
-import '../helper';
+import { expect } from 'chai';
 import {
     util,
     // @ts-ignore not declared as exported
@@ -7,242 +6,251 @@ import {
     enums
 } from 'openpgp';
 
-import { decryptPrivateKey, getMessage, verifyMessage, encryptMessage, decryptMessage, createMessage, getSignature,  } from '../../lib';
+import {
+    decryptPrivateKey,
+    getMessage,
+    verifyMessage,
+    encryptMessage,
+    decryptMessage,
+    createMessage,
+    getSignature
+} from '../../lib';
 import { testPrivateKeyLegacy } from './decryptMessageLegacy.data';
 import { VERIFICATION_STATUS } from '../../lib/constants';
 import { openpgp } from '../../lib/openpgp';
 
-test('it can encrypt and decrypt a message', async (t) => {
-    const decryptedPrivateKey = await decryptPrivateKey(testPrivateKeyLegacy, '123');
-    const { data: encrypted } = await encryptMessage({
-        message: createMessage('Hello world!'),
-        publicKeys: [decryptedPrivateKey.toPublic()],
-        privateKeys: [decryptedPrivateKey]
+describe('encryptMessage', () => {
+    it('it can encrypt and decrypt a message', async () => {
+        const decryptedPrivateKey = await decryptPrivateKey(testPrivateKeyLegacy, '123');
+        const { data: encrypted } = await encryptMessage({
+            message: await createMessage('Hello world!'),
+            publicKeys: [decryptedPrivateKey.toPublic()],
+            privateKeys: [decryptedPrivateKey]
+        });
+        const { data: decrypted, verified } = await decryptMessage({
+            message: await getMessage(encrypted),
+            publicKeys: [decryptedPrivateKey.toPublic()],
+            privateKeys: [decryptedPrivateKey]
+        });
+        expect(decrypted).to.equal('Hello world!');
+        expect(verified).to.equal(VERIFICATION_STATUS.SIGNED_AND_VALID);
     });
-    const { data: decrypted, verified } = await decryptMessage({
-        message: await getMessage(encrypted),
-        publicKeys: [decryptedPrivateKey.toPublic()],
-        privateKeys: [decryptedPrivateKey]
-    });
-    t.is(decrypted, 'Hello world!');
-    t.is(verified, VERIFICATION_STATUS.SIGNED_AND_VALID);
-});
 
-test('it can encrypt and decrypt a message with session keys', async (t) => {
-    const decryptedPrivateKey = await decryptPrivateKey(testPrivateKeyLegacy, '123');
-    const { data: encrypted, sessionKey: sessionKeys } = await encryptMessage({
-        message: createMessage('Hello world!'),
-        publicKeys: [decryptedPrivateKey.toPublic()],
-        privateKeys: [decryptedPrivateKey],
-        returnSessionKey: true
+    it('it can encrypt and decrypt a message with session keys', async () => {
+        const decryptedPrivateKey = await decryptPrivateKey(testPrivateKeyLegacy, '123');
+        const { data: encrypted, sessionKey } = await encryptMessage({
+            message: await createMessage('Hello world!'),
+            publicKeys: [decryptedPrivateKey.toPublic()],
+            privateKeys: [decryptedPrivateKey],
+            returnSessionKey: true
+        });
+        const { data: decrypted, verified } = await decryptMessage({
+            message: await getMessage(encrypted),
+            publicKeys: [decryptedPrivateKey.toPublic()],
+            sessionKeys: sessionKey
+        });
+        expect(decrypted).to.equal('Hello world!');
+        expect(verified).to.equal(VERIFICATION_STATUS.SIGNED_AND_VALID);
     });
-    const { data: decrypted, verified } = await decryptMessage({
-        message: await getMessage(encrypted),
-        publicKeys: [decryptedPrivateKey.toPublic()],
-        sessionKeys
-    });
-    t.is(decrypted, 'Hello world!');
-    t.is(verified, VERIFICATION_STATUS.SIGNED_AND_VALID);
-});
 
-test('it does not compress a message by default', async (t) => {
-    const decryptedPrivateKey = await decryptPrivateKey(testPrivateKeyLegacy, '123');
-    const { data: encrypted, sessionKey: sessionKeys } = await encryptMessage({
-        message: createMessage('Hello world!'),
-        publicKeys: [decryptedPrivateKey.toPublic()],
-        privateKeys: [decryptedPrivateKey],
-        returnSessionKey: true
+    it('it does not compress a message by default', async () => {
+        const decryptedPrivateKey = await decryptPrivateKey(testPrivateKeyLegacy, '123');
+        const { data: encrypted, sessionKey } = await encryptMessage({
+            message: await createMessage('Hello world!'),
+            publicKeys: [decryptedPrivateKey.toPublic()],
+            privateKeys: [decryptedPrivateKey],
+            returnSessionKey: true
+        });
+        const encryptedMessage = await getMessage(encrypted);
+        const decryptedMessage = await encryptedMessage.decrypt([], [], [sessionKey]);
+        expect(decryptedMessage.packets.findPacket(enums.packet.compressed)).to.equal(undefined);
     });
-    const encryptedMessage = await getMessage(encrypted);
-    const decryptedMessage = await encryptedMessage.decrypt([], [], [sessionKeys]);
-    t.is(decryptedMessage.packets.findPacket(enums.packet.compressed), undefined);
-});
 
-test('it compresses the message if the compression option is specified', async (t) => {
-    const decryptedPrivateKey = await decryptPrivateKey(testPrivateKeyLegacy, '123');
-    const { data: encrypted, sessionKey: sessionKeys } = await encryptMessage({
-        message: createMessage('Hello world!'),
-        publicKeys: [decryptedPrivateKey.toPublic()],
-        privateKeys: [decryptedPrivateKey],
-        returnSessionKey: true,
-        compression: enums.compression.zip
+    it('it compresses the message if the compression option is specified', async () => {
+        const decryptedPrivateKey = await decryptPrivateKey(testPrivateKeyLegacy, '123');
+        const { data: encrypted, sessionKey: sessionKeys } = await encryptMessage({
+            message: await createMessage('Hello world!'),
+            publicKeys: [decryptedPrivateKey.toPublic()],
+            privateKeys: [decryptedPrivateKey],
+            returnSessionKey: true,
+            compression: enums.compression.zip
+        });
+        const encryptedMessage = await getMessage(encrypted);
+        const decryptedMessage = await encryptedMessage.decrypt([], [], [sessionKeys]);
+        const compressedPacket = decryptedMessage.packets.findPacket(enums.packet.compressed) as openpgp.packet.Compressed;
+        expect(compressedPacket).to.not.be.undefined;
+        expect(compressedPacket.algorithm).to.equal('zip');
     });
-    const encryptedMessage = await getMessage(encrypted);
-    const decryptedMessage = await encryptedMessage.decrypt([], [], [sessionKeys]);
-    const compressedPacket = decryptedMessage.packets.findPacket(enums.packet.compressed) as openpgp.packet.Compressed;
-    t.not(compressedPacket, undefined);
-    t.is(compressedPacket.algorithm, 'zip');
-});
 
-test('it can encrypt and decrypt a message with an unencrypted detached signature', async (t) => {
-    const decryptedPrivateKey = await decryptPrivateKey(testPrivateKeyLegacy, '123');
-    const { data: encrypted, signature } = await encryptMessage({
-        message: createMessage('Hello world!'),
-        publicKeys: [decryptedPrivateKey.toPublic()],
-        privateKeys: [decryptedPrivateKey],
-        detached: true
+    it('it can encrypt and decrypt a message with an unencrypted detached signature', async () => {
+        const decryptedPrivateKey = await decryptPrivateKey(testPrivateKeyLegacy, '123');
+        const { data: encrypted, signature } = await encryptMessage({
+            message: await createMessage('Hello world!'),
+            publicKeys: [decryptedPrivateKey.toPublic()],
+            privateKeys: [decryptedPrivateKey],
+            detached: true
+        });
+        const { data: decrypted, verified } = await decryptMessage({
+            message: await getMessage(encrypted),
+            signature: await getSignature(signature),
+            publicKeys: [decryptedPrivateKey.toPublic()],
+            privateKeys: [decryptedPrivateKey]
+        });
+        expect(decrypted).to.equal('Hello world!');
+        expect(verified).to.equal(VERIFICATION_STATUS.SIGNED_AND_VALID);
+        const { verified: verifiedAgain } = await verifyMessage({
+            message: await createMessage('Hello world!'),
+            signature: await getSignature(signature),
+            publicKeys: [decryptedPrivateKey.toPublic()]
+        });
+        expect(verifiedAgain).to.equal(VERIFICATION_STATUS.SIGNED_AND_VALID);
     });
-    const { data: decrypted, verified } = await decryptMessage({
-        message: await getMessage(encrypted),
-        signature: await getSignature(signature),
-        publicKeys: [decryptedPrivateKey.toPublic()],
-        privateKeys: [decryptedPrivateKey]
-    });
-    t.is(decrypted, 'Hello world!');
-    t.is(verified, VERIFICATION_STATUS.SIGNED_AND_VALID);
-    const { verified: verifiedAgain } = await verifyMessage({
-        message: createMessage('Hello world!'),
-        signature: await getSignature(signature),
-        publicKeys: [decryptedPrivateKey.toPublic()]
-    });
-    t.is(verifiedAgain, VERIFICATION_STATUS.SIGNED_AND_VALID);
-});
 
-test('it can encrypt and decrypt a message with an encrypted detached signature', async (t) => {
-    const decryptedPrivateKey = await decryptPrivateKey(testPrivateKeyLegacy, '123');
-    const { data: encrypted, encryptedSignature } = await encryptMessage({
-        message: createMessage('Hello world!'),
-        publicKeys: [decryptedPrivateKey.toPublic()],
-        privateKeys: [decryptedPrivateKey],
-        detached: true
+    it('it can encrypt and decrypt a message with an encrypted detached signature', async () => {
+        const decryptedPrivateKey = await decryptPrivateKey(testPrivateKeyLegacy, '123');
+        const { data: encrypted, encryptedSignature } = await encryptMessage({
+            message: await createMessage('Hello world!'),
+            publicKeys: [decryptedPrivateKey.toPublic()],
+            privateKeys: [decryptedPrivateKey],
+            detached: true
+        });
+        const { data: decrypted, verified } = await decryptMessage({
+            message: await getMessage(encrypted),
+            encryptedSignature: await getMessage(encryptedSignature),
+            publicKeys: [decryptedPrivateKey.toPublic()],
+            privateKeys: [decryptedPrivateKey]
+        });
+        expect(decrypted).to.equal('Hello world!');
+        expect(verified).to.equal(VERIFICATION_STATUS.SIGNED_AND_VALID);
     });
-    const { data: decrypted, verified } = await decryptMessage({
-        message: await getMessage(encrypted),
-        encryptedSignature: await getMessage(encryptedSignature),
-        publicKeys: [decryptedPrivateKey.toPublic()],
-        privateKeys: [decryptedPrivateKey]
-    });
-    t.is(decrypted, 'Hello world!');
-    t.is(verified, VERIFICATION_STATUS.SIGNED_AND_VALID);
-});
 
-test('it can encrypt a message and decrypt it unarmored using session keys along with an encrypted detached signature', async (t) => {
-    const decryptedPrivateKey = await decryptPrivateKey(testPrivateKeyLegacy, '123');
-    const { message: encrypted, sessionKey: sessionKeys, encryptedSignature } = await encryptMessage({
-        message: createMessage('Hello world!'),
-        publicKeys: [decryptedPrivateKey.toPublic()],
-        privateKeys: [decryptedPrivateKey],
-        returnSessionKey: true,
-        detached: true,
-        armor: false
+    it('it can encrypt a message and decrypt it unarmored using session keys along with an encrypted detached signature', async () => {
+        const decryptedPrivateKey = await decryptPrivateKey(testPrivateKeyLegacy, '123');
+        const { message: encrypted, sessionKey: sessionKeys, encryptedSignature } = await encryptMessage({
+            message: await createMessage('Hello world!'),
+            publicKeys: [decryptedPrivateKey.toPublic()],
+            privateKeys: [decryptedPrivateKey],
+            returnSessionKey: true,
+            detached: true,
+            armor: false
+        });
+        const { data: decrypted, verified } = await decryptMessage({
+            message: await getMessage(encrypted),
+            publicKeys: [decryptedPrivateKey.toPublic()],
+            encryptedSignature: await getMessage(encryptedSignature),
+            sessionKeys
+        });
+        expect(decrypted).to.equal('Hello world!');
+        expect(verified).to.equal(VERIFICATION_STATUS.SIGNED_AND_VALID);
     });
-    const { data: decrypted, verified } = await decryptMessage({
-        message: await getMessage(encrypted),
-        publicKeys: [decryptedPrivateKey.toPublic()],
-        encryptedSignature: await getMessage(encryptedSignature),
-        sessionKeys
-    });
-    t.is(decrypted, 'Hello world!');
-    t.is(verified, VERIFICATION_STATUS.SIGNED_AND_VALID);
-});
 
-test('it can encrypt and decrypt a message with session key without setting returnSessionKey', async (t) => {
-    const decryptedPrivateKey = await decryptPrivateKey(testPrivateKeyLegacy, '123');
-    const sessionKey = {
-        data: util.hex_to_Uint8Array('c5629d840fd64ef55aea474f87dcdeef76bbc798a340ef67045315eb7924a36f'),
-        algorithm: 'aes256'
-    };
-    const { data: encrypted } = await encryptMessage({
-        message: createMessage('Hello world!'),
-        publicKeys: [decryptedPrivateKey.toPublic()],
-        privateKeys: [decryptedPrivateKey],
-        sessionKey
+    it('it can encrypt and decrypt a message with session key without setting returnSessionKey', async () => {
+        const decryptedPrivateKey = await decryptPrivateKey(testPrivateKeyLegacy, '123');
+        const sessionKey = {
+            data: util.hex_to_Uint8Array('c5629d840fd64ef55aea474f87dcdeef76bbc798a340ef67045315eb7924a36f'),
+            algorithm: 'aes256'
+        };
+        const { data: encrypted } = await encryptMessage({
+            message: await createMessage('Hello world!'),
+            publicKeys: [decryptedPrivateKey.toPublic()],
+            privateKeys: [decryptedPrivateKey],
+            sessionKey
+        });
+        const { data: decrypted, verified } = await decryptMessage({
+            message: await getMessage(encrypted),
+            publicKeys: [decryptedPrivateKey.toPublic()],
+            sessionKeys: sessionKey
+        });
+        expect(decrypted).to.equal('Hello world!');
+        expect(verified).to.equal(VERIFICATION_STATUS.SIGNED_AND_VALID);
     });
-    const { data: decrypted, verified } = await decryptMessage({
-        message: await getMessage(encrypted),
-        publicKeys: [decryptedPrivateKey.toPublic()],
-        sessionKeys: sessionKey
-    });
-    t.is(decrypted, 'Hello world!');
-    t.is(verified, VERIFICATION_STATUS.SIGNED_AND_VALID);
-});
 
-test('it can encrypt and decrypt a message with session key without setting returnSessionKey with a detached signature', async (t) => {
-    const decryptedPrivateKey = await decryptPrivateKey(testPrivateKeyLegacy, '123');
-    const sessionKey = {
-        data: util.hex_to_Uint8Array('c5629d840fd64ef55aea474f87dcdeef76bbc798a340ef67045315eb7924a36f'),
-        algorithm: 'aes256'
-    };
-    const { data: encrypted, encryptedSignature } = await encryptMessage({
-        message: createMessage('Hello world!'),
-        publicKeys: [decryptedPrivateKey.toPublic()],
-        privateKeys: [decryptedPrivateKey],
-        detached: true,
-        sessionKey
+    it('it can encrypt and decrypt a message with session key without setting returnSessionKey with a detached signature', async () => {
+        const decryptedPrivateKey = await decryptPrivateKey(testPrivateKeyLegacy, '123');
+        const sessionKey = {
+            data: util.hex_to_Uint8Array('c5629d840fd64ef55aea474f87dcdeef76bbc798a340ef67045315eb7924a36f'),
+            algorithm: 'aes256'
+        };
+        const { data: encrypted, encryptedSignature } = await encryptMessage({
+            message: await createMessage('Hello world!'),
+            publicKeys: [decryptedPrivateKey.toPublic()],
+            privateKeys: [decryptedPrivateKey],
+            detached: true,
+            sessionKey
+        });
+        const { data: decrypted, verified } = await decryptMessage({
+            message: await getMessage(encrypted),
+            publicKeys: [decryptedPrivateKey.toPublic()],
+            encryptedSignature: await getMessage(encryptedSignature),
+            sessionKeys: sessionKey
+        });
+        expect(decrypted).to.equal('Hello world!');
+        expect(verified).to.equal(VERIFICATION_STATUS.SIGNED_AND_VALID);
     });
-    const { data: decrypted, verified } = await decryptMessage({
-        message: await getMessage(encrypted),
-        publicKeys: [decryptedPrivateKey.toPublic()],
-        encryptedSignature: await getMessage(encryptedSignature),
-        sessionKeys: sessionKey
-    });
-    t.is(decrypted, 'Hello world!');
-    t.is(verified, VERIFICATION_STATUS.SIGNED_AND_VALID);
-});
 
-test('it can encrypt and decrypt a binary streamed message with an unencrypted detached signature', async (t) => {
-    const decryptedPrivateKey = await decryptPrivateKey(testPrivateKeyLegacy, '123');
-    const { message: encrypted, sessionKey: sessionKeys, signature } = await encryptMessage({
-        message: createMessage('Hello world!'),
-        publicKeys: [decryptedPrivateKey.toPublic()],
-        privateKeys: [decryptedPrivateKey],
-        streaming: 'web',
-        armor: false,
-        returnSessionKey: true,
-        detached: true
+    it('it can encrypt and decrypt a binary streamed message with an unencrypted detached signature', async () => {
+        const decryptedPrivateKey = await decryptPrivateKey(testPrivateKeyLegacy, '123');
+        const { message: encrypted, sessionKey: sessionKeys, signature } = await encryptMessage({
+            message: createMessage('Hello world!'),
+            publicKeys: [decryptedPrivateKey.toPublic()],
+            privateKeys: [decryptedPrivateKey],
+            armor: false,
+            returnSessionKey: true,
+            detached: true
+        });
+        const { data: decrypted, verified } = await decryptMessage({
+            message: await getMessage(encrypted),
+            signature: await getSignature(signature),
+            sessionKeys,
+            publicKeys: [decryptedPrivateKey.toPublic()],
+            streaming: 'web',
+            format: 'binary'
+        });
+        expect(util.Uint8Array_to_str(await stream.readToEnd(decrypted))).to.equal('Hello world!');
+        expect(await verified).to.equal(VERIFICATION_STATUS.SIGNED_AND_VALID);
     });
-    const { data: decrypted, verified } = await decryptMessage({
-        message: await getMessage(encrypted),
-        signature: await getSignature(signature),
-        sessionKeys,
-        publicKeys: [decryptedPrivateKey.toPublic()],
-        streaming: 'web',
-        format: 'binary'
-    });
-    t.is(util.Uint8Array_to_str(await stream.readToEnd(decrypted)), 'Hello world!');
-    t.is(await verified, VERIFICATION_STATUS.SIGNED_AND_VALID);
-});
 
-test('it can encrypt and decrypt a binary streamed message with an encrypted detached signature', async (t) => {
-    const decryptedPrivateKey = await decryptPrivateKey(testPrivateKeyLegacy, '123');
-    const { message: encrypted, sessionKey: sessionKeys, encryptedSignature } = await encryptMessage({
-        message: createMessage('Hello world!'),
-        publicKeys: [decryptedPrivateKey.toPublic()],
-        privateKeys: [decryptedPrivateKey],
-        streaming: 'web',
-        armor: false,
-        returnSessionKey: true,
-        detached: true
+    it('it can encrypt and decrypt a binary streamed message with an encrypted detached signature', async () => {
+        const decryptedPrivateKey = await decryptPrivateKey(testPrivateKeyLegacy, '123');
+        const { message: encrypted, sessionKey: sessionKeys, encryptedSignature } = await encryptMessage({
+            message: createMessage('Hello world!'),
+            publicKeys: [decryptedPrivateKey.toPublic()],
+            privateKeys: [decryptedPrivateKey],
+            streaming: 'web',
+            armor: false,
+            returnSessionKey: true,
+            detached: true
+        });
+        const { data: decrypted, verified } = await decryptMessage({
+            message: await getMessage(encrypted),
+            encryptedSignature: await getMessage(encryptedSignature),
+            sessionKeys,
+            publicKeys: [decryptedPrivateKey.toPublic()],
+            streaming: 'web',
+            format: 'binary'
+        });
+        expect(util.Uint8Array_to_str(await stream.readToEnd(decrypted))).to.equal('Hello world!');
+        expect(await verified).to.equal(VERIFICATION_STATUS.SIGNED_AND_VALID);
     });
-    const { data: decrypted, verified } = await decryptMessage({
-        message: await getMessage(encrypted),
-        encryptedSignature: await getMessage(encryptedSignature),
-        sessionKeys,
-        publicKeys: [decryptedPrivateKey.toPublic()],
-        streaming: 'web',
-        format: 'binary'
-    });
-    t.is(util.Uint8Array_to_str(await stream.readToEnd(decrypted)), 'Hello world!');
-    t.is(await verified, VERIFICATION_STATUS.SIGNED_AND_VALID);
-});
 
-test('it can encrypt and decrypt a binary streamed message with in-message signature', async (t) => {
-    const decryptedPrivateKey = await decryptPrivateKey(testPrivateKeyLegacy, '123');
-    const { message: encrypted, sessionKey: sessionKeys } = await encryptMessage({
-        message: createMessage('Hello world!'),
-        publicKeys: [decryptedPrivateKey.toPublic()],
-        privateKeys: [decryptedPrivateKey],
-        streaming: 'web',
-        armor: false,
-        returnSessionKey: true
+    it('it can encrypt and decrypt a binary streamed message with in-message signature', async () => {
+        const decryptedPrivateKey = await decryptPrivateKey(testPrivateKeyLegacy, '123');
+        const { message: encrypted, sessionKey: sessionKeys } = await encryptMessage({
+            message: createMessage('Hello world!'),
+            publicKeys: [decryptedPrivateKey.toPublic()],
+            privateKeys: [decryptedPrivateKey],
+            streaming: 'web',
+            armor: false,
+            returnSessionKey: true
+        });
+        const { data: decrypted, verified } = await decryptMessage({
+            message: await getMessage(encrypted),
+            sessionKeys,
+            publicKeys: [decryptedPrivateKey.toPublic()],
+            streaming: 'web',
+            format: 'binary'
+        });
+        expect(util.Uint8Array_to_str(await stream.readToEnd(decrypted))).to.equal('Hello world!');
+        expect(await verified).to.equal(VERIFICATION_STATUS.SIGNED_AND_VALID);
     });
-    const { data: decrypted, verified } = await decryptMessage({
-        message: await getMessage(encrypted),
-        sessionKeys,
-        publicKeys: [decryptedPrivateKey.toPublic()],
-        streaming: 'web',
-        format: 'binary'
-    });
-    t.is(util.Uint8Array_to_str(await stream.readToEnd(decrypted)), 'Hello world!');
-    t.is(await verified, VERIFICATION_STATUS.SIGNED_AND_VALID);
 });

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,0 +1,11 @@
+import { use as chaiUse } from 'chai';
+import * as chaiAsPromised from 'chai-as-promised';
+import * as openpgp from 'openpgp';
+
+import { init } from '../lib/pmcrypto';
+
+chaiUse(chaiAsPromised);
+
+before(() => {
+    init(openpgp);
+});


### PR DESCRIPTION
I backported @larabr's PR here https://github.com/ProtonMail/pmcrypto/pull/130 to the current (old) version of pmcrypto because we're running into a memory leak issue with jest and pmcrypto due to esm. It also seems to have a new problem with the latest version of @babel/register. So since we're planing to remove it, I thought it would be nice to already backport it. I copied your work and applied it on the old branch @larabr, though I isolated it to karma and esm. I did not update eslint.