### PR TITLE
[v7] Add support for binary output in `encrypt/signMessage`: replace `armor` option with `format`

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -138,6 +138,8 @@ export function decryptMIMEMessage(
 
 type MaybeStream<T extends Uint8Array | string> = T | WebStream<T>;
 type Data = string | Uint8Array;
+export { WebStream };
+
 export interface EncryptOptionsPmcryptoWithTextData<T extends MaybeStream<string>> extends Omit<EncryptOptions, 'message'> {
     textData: T;
     binaryData?: undefined;

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -12,7 +12,8 @@ import {
     generateKey,
     PrivateKey,
     SessionKey,
-    encryptSessionKey
+    encryptSessionKey,
+    WebStream
 } from 'openpgp/lightweight';
 
 export function init(): void;
@@ -45,8 +46,7 @@ export interface DecryptMimeOptions extends DecryptLegacyOptions {
 }
 
 // No reuse from OpenPGP's equivalent
-export interface EncryptResult<D = undefined, M = undefined, S = undefined, E = undefined> {
-    data: D;
+export interface EncryptResult<M = undefined, S = undefined, E = undefined> {
     message: M;
     signature: S;
     sessionKey: SessionKey;
@@ -117,10 +117,10 @@ export type DecryptResultPmcrypto = Omit<DecryptMessageResult, 'signatures'> & {
 
 export function decryptMessage(
     options: DecryptOptionsPmcrypto & { format: 'utf8' }
-): Promise<DecryptResultPmcrypto & { data: string | ReadableStream<string> }>;
+): Promise<DecryptResultPmcrypto & { data: string | WebStream<string> }>;
 export function decryptMessage(
     options: DecryptOptionsPmcrypto & { format: 'binary' }
-): Promise<DecryptResultPmcrypto & { data: Uint8Array | ReadableStream<Uint8Array> }>;
+): Promise<DecryptResultPmcrypto & { data: Uint8Array | WebStream<Uint8Array> }>;
 export function decryptMessage(options: DecryptOptionsPmcrypto): Promise<DecryptResultPmcrypto>;
 
 export function decryptMessageLegacy(options: DecryptLegacyOptions): Promise<DecryptResultPmcrypto>;
@@ -136,44 +136,56 @@ export function decryptMIMEMessage(
     signatures: OpenPGPSignature[];
 }>;
 
-type MaybeStream<T extends Uint8Array | string> = T | ReadableStream<T>;
-export interface EncryptOptionsPmcryptoWithTextData extends Omit<EncryptOptions, 'message'> {
-    textData: MaybeStream<string>;
+type MaybeStream<T extends Uint8Array | string> = T | WebStream<T>;
+type Data = string | Uint8Array;
+export interface EncryptOptionsPmcryptoWithTextData<T extends MaybeStream<string>> extends Omit<EncryptOptions, 'message'> {
+    textData: T;
     binaryData?: undefined;
     stripTrailingSpaces?: boolean;
 }
-export interface EncryptOptionsPmcryptoWithBinaryData extends Omit<EncryptOptions, 'message'> {
+export interface EncryptOptionsPmcryptoWithBinaryData<T extends MaybeStream<Uint8Array>> extends Omit<EncryptOptions, 'message'> {
     textData?: undefined;
-    binaryData: MaybeStream<Uint8Array>;
+    binaryData: T;
     stripTrailingSpaces?: undefined;
 }
-type EncryptOptionsPmcrypto = (EncryptOptionsPmcryptoWithBinaryData | EncryptOptionsPmcryptoWithTextData) & {
+type EncryptOptionsPmcryptoWithData<T extends MaybeStream<Data>> =
+    T extends MaybeStream<string> ? EncryptOptionsPmcryptoWithTextData<T> :
+    T extends MaybeStream<Uint8Array> ? EncryptOptionsPmcryptoWithBinaryData<T> :
+    never;
+
+type EncryptOptionsPmcrypto<T extends MaybeStream<Data>> = EncryptOptionsPmcryptoWithData<T> & {
     returnSessionKey?: boolean;
     detached?: boolean;
 };
 
-export function encryptMessage(
-    options: EncryptOptionsPmcrypto & { armor?: true; format?: 'armored'; detached?: false }
-): Promise<EncryptResult<string>>;
-export function encryptMessage(
-    options: EncryptOptionsPmcrypto & { armor?: true; format?: 'armored'; detached: true }
-): Promise<EncryptResult<string, undefined, string, string>>;
-export function encryptMessage(
-    options: EncryptOptionsPmcrypto & { armor: false; format?: 'object'; detached?: false }
-): Promise<EncryptResult<undefined, OpenPGPMessage>>;
-export function encryptMessage(
-    options: EncryptOptionsPmcrypto & { armor: false; format?: 'object'; detached: true }
-): Promise<EncryptResult<undefined, OpenPGPMessage, OpenPGPSignature, OpenPGPMessage>>;
-export function encryptMessage( // TODO what is this for? redundant -- declare maybe streams above
-    options: EncryptOptionsPmcrypto
-): Promise<
-    EncryptResult<
-        string | ReadableStream<string>,
-        OpenPGPMessage,
-        string | ReadableStream<string> | OpenPGPSignature,
-        string | ReadableStream<string> | OpenPGPMessage
-    >
+export function encryptMessage<T extends MaybeStream<Data>>(
+    options: EncryptOptionsPmcrypto<T> & { format?: 'armored'; detached?: false }
+): Promise<T extends WebStream<string> ? EncryptResult<WebStream<string>> : EncryptResult<string>>;
+export function encryptMessage<T extends MaybeStream<Data>>(
+    options: EncryptOptionsPmcrypto<T> & { format?: 'armored'; detached: true }
+): Promise<T extends WebStream<string> ?
+    EncryptResult<WebStream<string>, WebStream<string>, WebStream<string>> :
+    EncryptResult<string, string, string>
 >;
+export function encryptMessage<T extends MaybeStream<Data>>(
+    options: EncryptOptionsPmcrypto<T> & { format?: 'object'; detached?: false }
+): Promise<EncryptResult<OpenPGPMessage>>;
+export function encryptMessage<T extends MaybeStream<Data>>(
+    options: EncryptOptionsPmcrypto<T> & { format?: 'object'; detached: true }
+): Promise<EncryptResult<OpenPGPMessage, OpenPGPSignature, Uint8Array>>;
+export function encryptMessage<T extends MaybeStream<Data>>(
+    options: EncryptOptionsPmcrypto<T> & { format?: 'binary'; detached?: false }
+): Promise<T extends WebStream<Uint8Array> ?
+    EncryptResult<WebStream<Uint8Array>> :
+    EncryptResult<Uint8Array>
+>;
+export function encryptMessage<T extends MaybeStream<Data>>(
+    options: EncryptOptionsPmcrypto<T> & { format?: 'binary'; detached: true }
+): Promise<T extends WebStream<Uint8Array> ?
+    EncryptResult<WebStream<Uint8Array>, WebStream<Uint8Array>, WebStream<Uint8Array>> :
+    EncryptResult<Uint8Array, Uint8Array, Uint8Array>
+>;
+
 export function getMatchingKey(
     signature: OpenPGPSignature | OpenPGPMessage,
     publicKeys: OpenPGPKey[]

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -160,10 +160,10 @@ type EncryptOptionsPmcrypto<T extends MaybeStream<Data>> = EncryptOptionsPmcrypt
 
 export function encryptMessage<T extends MaybeStream<Data>>(
     options: EncryptOptionsPmcrypto<T> & { format?: 'armored'; detached?: false }
-): Promise<T extends WebStream<string> ? EncryptResult<WebStream<string>> : EncryptResult<string>>;
+): Promise<T extends WebStream<Data> ? EncryptResult<WebStream<string>> : EncryptResult<string>>;
 export function encryptMessage<T extends MaybeStream<Data>>(
     options: EncryptOptionsPmcrypto<T> & { format?: 'armored'; detached: true }
-): Promise<T extends WebStream<string> ?
+): Promise<T extends WebStream<Data> ?
     EncryptResult<WebStream<string>, WebStream<string>, WebStream<string>> :
     EncryptResult<string, string, string>
 >;
@@ -175,13 +175,13 @@ export function encryptMessage<T extends MaybeStream<Data>>(
 ): Promise<EncryptResult<OpenPGPMessage, OpenPGPSignature, Uint8Array>>;
 export function encryptMessage<T extends MaybeStream<Data>>(
     options: EncryptOptionsPmcrypto<T> & { format?: 'binary'; detached?: false }
-): Promise<T extends WebStream<Uint8Array> ?
+): Promise<T extends WebStream<Data> ?
     EncryptResult<WebStream<Uint8Array>> :
     EncryptResult<Uint8Array>
 >;
 export function encryptMessage<T extends MaybeStream<Data>>(
     options: EncryptOptionsPmcrypto<T> & { format?: 'binary'; detached: true }
-): Promise<T extends WebStream<Uint8Array> ?
+): Promise<T extends WebStream<Data> ?
     EncryptResult<WebStream<Uint8Array>, WebStream<Uint8Array>, WebStream<Uint8Array>> :
     EncryptResult<Uint8Array, Uint8Array, Uint8Array>
 >;
@@ -208,10 +208,10 @@ type SignOptionsPmcrypto<T extends MaybeStream<Data>> =
 
 export function signMessage<T extends MaybeStream<Data>>(
     options: SignOptionsPmcrypto<T> & { format?: 'armored' }
-): Promise<T extends WebStream<string> ? WebStream<string> : string>;
+): Promise<T extends WebStream<Data> ? WebStream<string> : string>;
 export function signMessage<T extends MaybeStream<Data>>(
     options: SignOptionsPmcrypto<T> & { format: 'binary'; }
-): Promise<T extends WebStream<Uint8Array> ? WebStream<Uint8Array> : Uint8Array>;
+): Promise<T extends WebStream<Data> ? WebStream<Uint8Array> : Uint8Array>;
 export function signMessage<T extends MaybeStream<Data>>(
     options: SignOptionsPmcrypto<T> & { format: 'object'; detached?: false }
 ): Promise<OpenPGPMessage>;

--- a/lib/message/encrypt.js
+++ b/lib/message/encrypt.js
@@ -8,18 +8,14 @@ export default async function encryptMessage({
     binaryData,
     returnSessionKey,
     stripTrailingSpaces,
+    format = 'armored',
     date = serverTime(),
-    armor = true,
     detached = false,
     ...options
 }) {
-    const sanitizedOptions = { ...options, date };
+    const sanitizedOptions = { ...options, date, format };
     const dataType = binaryData ? 'binary' : 'text';
     const data = binaryData || (stripTrailingSpaces ? removeTrailingSpaces(textData) : textData); // throw if streamed text and stripTrailingSpaces enabled
-
-    if (!options.format) {
-        sanitizedOptions.format = armor ? 'armored' : 'object'; // TODO change, remove `armor` param?
-    }
 
     if (!options.sessionKey) {
         sanitizedOptions.sessionKey = await generateSessionKey({
@@ -36,8 +32,8 @@ export default async function encryptMessage({
     }
 
     if (detached) {
-        if (!armor && isStream(data)) {
-            throw new Error('Unsupported detached signature when streaming data and requesting non-armored result');
+        if (format === 'object' && isStream(data)) {
+            throw new Error('Unsupported detached signature when streaming data and requesting "object" result');
         }
 
         const detachedSignatureBinary = await sign({
@@ -59,23 +55,17 @@ export default async function encryptMessage({
             message: await createMessage({ binary: clone(detachedSignatureBinary), date }) // clone is very cheap for non-stream binary data (it just returns a subarray)
         });
 
-        result.signature = armor
+        result.signature = format === 'armored'
             ? openpgp_armor(enums.armor.signature, detachedSignatureBinary)
             : detachedSignatureBinary;
     }
 
-    const encrypted = await encrypt({
+    result.message = await encrypt({
         ...sanitizedOptions,
         message: await createMessage({ [dataType]: data, date }),
         // Encrypt message without signing it if we store a separate detached signature
         signingKeys: detached ? [] : sanitizedOptions.signingKeys
     });
-
-    if (armor) {
-        result.data = encrypted;
-    } else {
-        result.message = encrypted;
-    }
 
     return result;
 }

--- a/lib/message/utils.js
+++ b/lib/message/utils.js
@@ -81,7 +81,7 @@ export async function getCleartextMessage(message) {
  * @param {String|ReadableStream<String>} textData - text data to sign
  * @param {Uint8Array|ReadableStream<Uint8Array>} binaryData - binary data to sign
  * @param {Boolean} stripTrailingSpaces - whether trailing spaces should be removed from `textData`
- * @returns Promise<{Message|Signature|String|ReadableStream<String>}> signed message object, signature object, or their corresponding armored data
+ * @returns Promise<{Message|Signature|MaybeStream<String>|MaybeStream<Uint8Array>}> signed message object, signature object, or corresponding serialised data
  * @throws on signing error
  */
 export async function signMessage({
@@ -89,7 +89,7 @@ export async function signMessage({
     binaryData,
     stripTrailingSpaces,
     date = serverTime(),
-    armor = true,
+    format = 'armored',
     ...options
 }) {
     const dataType = binaryData ? 'binary' : 'text';
@@ -97,11 +97,8 @@ export async function signMessage({
     const sanitizedOptions = {
         ...options,
         date,
+        format,
         message: await createMessage({ [dataType]: data, date })
-    }
-
-    if (!options.format) {
-        sanitizedOptions.format = armor ? 'armored' : 'object'; // TODO change, remove `armor` param?
     }
 
     return sign(sanitizedOptions).catch((err) => {

--- a/test/message/encryptMessage.spec.ts
+++ b/test/message/encryptMessage.spec.ts
@@ -1,9 +1,10 @@
 import { expect } from 'chai';
 // @ts-ignore missing web-stream-tools types
 import { readToEnd, ReadableStream, WritableStream, toStream } from '@openpgp/web-stream-tools';
-import { config, readMessage, CompressedDataPacket, enums, WebStream } from '../../lib/openpgp';
+import { config, readMessage, CompressedDataPacket, enums } from '../../lib/openpgp';
 
 import { decryptPrivateKey, getMessage, verifyMessage, encryptMessage, decryptMessage, getSignature, stringToUtf8Array } from '../../lib';
+import type { WebStream } from '../../lib';
 import { testPrivateKeyLegacy } from './decryptMessageLegacy.data';
 import { VERIFICATION_STATUS } from '../../lib/constants';
 import { hexToUint8Array, arrayToBinaryString } from '../../lib/utils';

--- a/test/message/encryptMessage.spec.ts
+++ b/test/message/encryptMessage.spec.ts
@@ -1,14 +1,14 @@
 import { expect } from 'chai';
 // @ts-ignore missing web-stream-tools types
 import { readToEnd, ReadableStream, WritableStream, toStream } from '@openpgp/web-stream-tools';
-import { config, readMessage, CompressedDataPacket, enums } from '../../lib/openpgp';
+import { config, readMessage, CompressedDataPacket, enums, WebStream } from '../../lib/openpgp';
 
-import { decryptPrivateKey, getMessage, verifyMessage, encryptMessage, decryptMessage, getSignature, stringToUtf8Array  } from '../../lib';
+import { decryptPrivateKey, getMessage, verifyMessage, encryptMessage, decryptMessage, getSignature, stringToUtf8Array } from '../../lib';
 import { testPrivateKeyLegacy } from './decryptMessageLegacy.data';
 import { VERIFICATION_STATUS } from '../../lib/constants';
 import { hexToUint8Array, arrayToBinaryString } from '../../lib/utils';
 
-const generateStreamOfData = (): { stream: ReadableStream<string>, data: string } => ({
+const generateStreamOfData = (): { stream: WebStream<string>, data: string } => ({
     stream: new ReadableStream({ pull: (controller: WritableStream) => { for (let i = 0; i < 10000; i++ ) { controller.enqueue('string'); } controller.close() } }),
     data: 'string'.repeat(10000)
 });

--- a/test/message/utils.spec.ts
+++ b/test/message/utils.spec.ts
@@ -129,7 +129,7 @@ describe('message utils', () => {
         expect(signatureTimestamp).to.be.null;
     });
 
-    it('signMessage/verifyMessage - it verifies a text message it has signed', async () => {
+    it('signMessage/verifyMessage - it verifies a text message it has signed (format = armored)', async () => {
         const { privateKey, publicKey } = await generateKey({
             userIDs: [{ name: 'name', email: 'email@test.com' }],
             date: new Date(),
@@ -137,7 +137,7 @@ describe('message utils', () => {
             format: 'object'
         });
 
-        const signature = await signMessage({
+        const armoredSignature = await signMessage({
             textData: 'message',
             signingKeys: [privateKey],
             detached: true
@@ -145,7 +145,31 @@ describe('message utils', () => {
 
         const verificationResult = await verifyMessage({
             textData: 'message',
-            signature: await getSignature(signature),
+            signature: await readSignature({ armoredSignature }),
+            verificationKeys: [publicKey]
+        });
+
+        expect(verificationResult.verified).to.equal(VERIFICATION_STATUS.SIGNED_AND_VALID);
+    });
+
+    it('signMessage/verifyMessage - it verifies a text message it has signed (format = binary)', async () => {
+        const { privateKey, publicKey } = await generateKey({
+            userIDs: [{ name: 'name', email: 'email@test.com' }],
+            date: new Date(),
+            keyExpirationTime: 10000,
+            format: 'object'
+        });
+
+        const binarySignature = await signMessage({
+            textData: 'message',
+            signingKeys: [privateKey],
+            detached: true,
+            format: 'binary'
+        });
+
+        const verificationResult = await verifyMessage({
+            textData: 'message',
+            signature: await readSignature({ binarySignature }),
             verificationKeys: [publicKey]
         });
 
@@ -176,7 +200,7 @@ describe('message utils', () => {
     });
 
     it('signMessage/verifyMessage - it verifies a streamed message it has signed', async () => {
-        const inputStream = new ReadableStream({
+        const inputStream: ReadableStream<string> = new ReadableStream({
             pull: (controller: WritableStream) => { for (let i = 0; i < 10000; i++ ) { controller.enqueue('string'); } controller.close() }
         });
         const inputData = 'string'.repeat(10000);

--- a/test/message/utils.spec.ts
+++ b/test/message/utils.spec.ts
@@ -4,6 +4,7 @@ import { WritableStream, ReadableStream, readToEnd } from '@openpgp/web-stream-t
 import { readKey, readSignature } from '../../lib/openpgp';
 import { verifyMessage, signMessage, getSignature, stringToUtf8Array, generateKey } from '../../lib';
 import { VERIFICATION_STATUS } from '../../lib/constants';
+import type { WebStream } from '../../lib';
 
 const detachedSignatureFromTwoKeys = `-----BEGIN PGP SIGNATURE-----
 
@@ -200,7 +201,7 @@ describe('message utils', () => {
     });
 
     it('signMessage/verifyMessage - it verifies a streamed message it has signed', async () => {
-        const inputStream: ReadableStream<string> = new ReadableStream({
+        const inputStream: WebStream<string> = new ReadableStream({
             pull: (controller: WritableStream) => { for (let i = 0; i < 10000; i++ ) { controller.enqueue('string'); } controller.close() }
         });
         const inputData = 'string'.repeat(10000);


### PR DESCRIPTION
The change improves support for outputting serialised data, which is safer to use since it is independent of internal changes in OpenPGP.js objects, which can be tricky to use e.g. in some streaming cases.

Breaking changes:
- in `sign/encryptMessage`, the option `armor: boolean` is replaced by `format: 'armored' | 'binary' | 'object'`. `format: 'armored'` is still the default and it is equivalent to `armor: true`.
- in `encryptMessage`, `result.data` has been removed, and the function always returns encrypted data as `result.message`.

Type definition changes:
- fix types to correctly infer whether the output data is streamed or not.
- replace `ReadableStream` with `WebStream`, since the former is not compatible with OpenPGP.js type declarations, due to the `AsyncIterable` not being implemented by all browsers (yet).