### PR TITLE
[v7] `processMIME`: take `data` as part of `options`, uniform default values and add TS definitions

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -11,6 +11,7 @@ import {
     reformatKey,
     generateKey,
     PrivateKey,
+    PublicKey,
     SessionKey,
     encryptSessionKey,
     WebStream
@@ -269,6 +270,37 @@ export interface VerifyMessageResult {
     errors?: Error[];
 }
 export function verifyMessage(options: VerifyOptionsPmcrypto): Promise<VerifyMessageResult>;
+
+export interface ProcessMIMEOptions {
+    verificationKeys?: PublicKey[],
+    date?: Date,
+    headerFilename?: string;
+    sender?: string;
+}
+
+// TODO? this definition is copied as-is from the webapps; some fields declared as optional might actually always be present
+export interface MIMEAttachment {
+    checksum?: string;
+    content: Uint8Array;
+    contentDisposition?: string;
+    contentId?: string;
+    contentType?: string;
+    fileName?: string;
+    generatedFileName?: string;
+    length?: number;
+    transferEncoding?: string;
+}
+
+export interface ProcessMIMEResult {
+    body?: string,
+    attachments: MIMEAttachment[],
+    verified: VERIFICATION_STATUS,
+    encryptedSubject: string,
+    mimetype?: 'text/html' | 'text/plain',
+    signatures: Signature[]
+}
+
+export function processMIME(options: ProcessMIMEOptions, data: string): Promise<ProcessMIMEResult>;
 
 export function serverTime(): Date;
 

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -272,6 +272,7 @@ export interface VerifyMessageResult {
 export function verifyMessage(options: VerifyOptionsPmcrypto): Promise<VerifyMessageResult>;
 
 export interface ProcessMIMEOptions {
+    data: string,
     verificationKeys?: PublicKey[],
     date?: Date,
     headerFilename?: string;
@@ -300,7 +301,7 @@ export interface ProcessMIMEResult {
     signatures: Signature[]
 }
 
-export function processMIME(options: ProcessMIMEOptions, data: string): Promise<ProcessMIMEResult>;
+export function processMIME(options: ProcessMIMEOptions): Promise<ProcessMIMEResult>;
 
 export function serverTime(): Date;
 

--- a/lib/message/processMIME.js
+++ b/lib/message/processMIME.js
@@ -161,11 +161,11 @@ const parse = async (
 /**
  * Process the mime structure in the right attachment.
  * @param {Object} options - options for signature verification and MIME processing
+ * @param {String} options.data - MIME data to process
  * @param {PublicKey[]} [options.verificationKeys]
  * @param {Date} [options.date] - to use for signature verification, instead of the server time
  * @param {String} [options.headerFilename] - the file name a memoryhole header should have
  * @param {String} [options.sender] - the address of the sender of this message
- * @param {String} data - MIME data to process
  * @return {Promise<{
  *      body: String | undefined,
  *      attachments: Object[],
@@ -175,7 +175,7 @@ const parse = async (
  *      signatures: Signature[]
  * }>}
  */
-export default async function processMIME(options, data) {
+export default async function processMIME({ data, ...options}) {
     const { subdata, verified, signatures } = await verifySignature(options, data);
 
     return parse(options, subdata, verified, signatures);

--- a/lib/message/processMIME.js
+++ b/lib/message/processMIME.js
@@ -72,7 +72,7 @@ const verifySignature = async ({ verificationKeys = [], date = serverTime() }, d
  * @param {VERIFICATION_STATUS} [verified]
  * @param {Signature[]} [signatures]
  * @returns {Promise<{
- *      body: String | undefined,
+ *      body: String,
  *      attachments: Object[],
  *      verified: VERIFICATION_STATUS,
  *      encryptedSubject: String,

--- a/lib/message/processMIME.js
+++ b/lib/message/processMIME.js
@@ -1,5 +1,6 @@
 import { getSignature, verifyMessage, removeTrailingSpaces } from './utils';
 import { VERIFICATION_STATUS, MAX_ENC_HEADER_LENGTH } from '../constants';
+import { serverTime } from '../serverTime';
 
 /**
  * Parse a mail into an object format, splitting, headers, html, text/plain and attachments. The result is defined
@@ -20,7 +21,7 @@ export const parseMail = (data) => {
     });
 };
 
-const verifySignature = async ({ publicKeys = [], date }, data) => {
+const verifySignature = async ({ verificationKeys = [], date = serverTime() }, data) => {
     const { headers } = await parseMail(data.split(/\r?\n\s*\r?\n/g)[0] + '\n\n');
     const contentType = headers['content-type'] || '';
     const [baseContentType] = contentType.split(';');
@@ -51,7 +52,7 @@ const verifySignature = async ({ publicKeys = [], date }, data) => {
     const { data: subdata, verified, signatures } = await verifyMessage({
         // The body is to be treated as CleartextMessage, see https://github.com/openpgpjs/openpgpjs/pull/1265#issue-830304843
         textData: removeTrailingSpaces(body),
-        verificationKeys: publicKeys,
+        verificationKeys,
         date,
         signature
     });
@@ -64,21 +65,30 @@ const verifySignature = async ({ publicKeys = [], date }, data) => {
  * inherit the verified status from the message verified status, as they are included in the body. For more
  * information see: https://tools.ietf.org/html/rfc2045, https://tools.ietf.org/html/rfc2046 and
  * https://tools.ietf.org/html/rfc2387.
- * @param headerFilename The file name a memoryhole header should have
- * @param sender the address of the sender of this message
- * @param content
- * @param verified
- * @returns {Promise.<*>}
+ * @param {Object} options
+ * @param {String} [options.headerFilename] - The file name a memoryhole header should have
+ * @param {String} [options.sender] - the address of the sender of this message
+ * @param {String} [content] - mail content to parse
+ * @param {VERIFICATION_STATUS} [verified]
+ * @param {Signature[]} [signatures]
+ * @returns {Promise<{
+ *      body: String | undefined,
+ *      attachments: Object[],
+ *      verified: VERIFICATION_STATUS,
+ *      encryptedSubject: String,
+ *      mimetype: 'text/html' | 'text/plain' | undefined,
+ *      signatures: Signature[]
+ * }>}
  */
 const parse = async (
-    { headerFilename = 'Encrypted Headers.txt', sender = null },
+    { headerFilename = 'Encrypted Headers.txt', sender = '' },
     content = '',
     verified = VERIFICATION_STATUS.NOT_VERIFIED,
-    signatures = undefined
+    signatures = []
 ) => {
     const data = await parseMail(content);
     // cf. https://github.com/autocrypt/memoryhole subject can be in the MIME headers
-    const { attachments = [], text = '', html = '', subject: mimeSubject = false } = data;
+    const { attachments = [], text = '', html = '', subject: mimeSubject = '' } = data;
 
     const result = await Promise.all(
         attachments.map(async (att) => {
@@ -137,9 +147,11 @@ const parse = async (
     }
     if (attachments.length) {
         return {
+            body: '',
             attachments,
             verified,
             encryptedSubject,
+            mimetype: undefined,
             signatures
         };
     }
@@ -148,9 +160,20 @@ const parse = async (
 
 /**
  * Process the mime structure in the right attachment.
- * @param options
- * @param data
- * @return {Promise<*>}
+ * @param {Object} options - options for signature verification and MIME processing
+ * @param {PublicKey[]} [options.verificationKeys]
+ * @param {Date} [options.date] - to use for signature verification, instead of the server time
+ * @param {String} [options.headerFilename] - the file name a memoryhole header should have
+ * @param {String} [options.sender] - the address of the sender of this message
+ * @param {String} data - MIME data to process
+ * @return {Promise<{
+ *      body: String | undefined,
+ *      attachments: Object[],
+ *      verified: VERIFICATION_STATUS,
+ *      encryptedSubject: String,
+ *      mimetype: 'text/html' | 'text/plain' | undefined,
+ *      signatures: Signature[]
+ * }>}
  */
 export default async function processMIME(options, data) {
     const { subdata, verified, signatures } = await verifySignature(options, data);

--- a/lib/pmcrypto.js
+++ b/lib/pmcrypto.js
@@ -59,7 +59,7 @@ export {
     armorBytes
 } from './message/utils';
 
-export { parseMail } from './message/processMIME';
+export { parseMail, default as processMIME } from './message/processMIME';
 
 export { default as keyInfo, getSHA256Fingerprints } from './key/info';
 

--- a/test/key/processMIME.data.ts
+++ b/test/key/processMIME.data.ts
@@ -138,3 +138,60 @@ euiL4uYD
 
 --=-=pj+EhsWuSQJxx7=-=
 `;
+
+// Message from: https://docs.microsoft.com/en-us/previous-versions/office/developer/exchange-server-2010/aa563375(v=exchg.140)
+export const multipartMessageWithAttachment = `From: Some One <someone@example.com>
+To: "Someone Else" <someone-else@example.com>
+MIME-Version: 1.0
+Content-Type: multipart/mixed; boundary="XXXXboundary text"
+
+This is a multipart message in MIME format.
+
+--XXXXboundary text
+Content-Type: text/plain
+
+this is the body text
+
+--XXXXboundary text
+Content-Type: text/plain;
+Content-Disposition: attachment; filename="test.txt"
+
+this is the attachment text
+
+--XXXXboundary text--`;
+
+// NB: this message signature is invalid and not verifiable using `key`.
+export const multipartMessageWithEncryptedSubject = `From: "Some One" <someone@example.com>
+To: "Someone Else" <someone-else@example.com>
+Subject: ...
+Mime-Version: 1.0
+Content-Type: multipart/signed; micalg=pgp-sha256; protocol="application/pgp-signature"; boundary="------------w7atwMAiUaHQsKDKV5d0o0kr"
+
+This is an OpenPGP/MIME signed message (RFC 4880 and 3156)
+--------------w7atwMAiUaHQsKDKV5d0o0kr
+Content-Type: multipart/mixed; boundary="------------nUB097wGzA443Ku03aYWQKqa"; protected-headers="v1"
+Subject: Encrypted subject
+From: "Some One" <someone@example.com>
+To: "Someone Else" <someone-else@example.com>
+
+--------------nUB097wGzA443Ku03aYWQKqa
+Content-Type: text/plain; charset=iso-8859-1
+Content-Transfer-Encoding: quoted-printable
+
+hello
+--------------nUB097wGzA443Ku03aYWQKqa--
+
+--------------w7atwMAiUaHQsKDKV5d0o0kr
+Content-Type: application/pgp-signature; name="OpenPGP_signature.asc"
+Content-Description: OpenPGP digital signature
+Content-Disposition: attachment; filename="OpenPGP_signature"
+
+-----BEGIN PGP SIGNATURE-----
+
+wnUEARYKAAYFAmIwlfMAIQkQdqGsuYvE1jgWIQRGvajOG9a8ZbdysiN2oay5
+i8TWOBX5AP0V5H79/eiraXKKBCvpqwcEzrv1DHfhvrjTHk9L6PIadgD/fXdv
+WTyjgksKkPV68HhW1CIKZ4JIMe726uldjP6tgw8=
+=nHao
+-----END PGP SIGNATURE-----
+
+--------------w7atwMAiUaHQsKDKV5d0o0kr--`;

--- a/test/key/processMIME.spec.ts
+++ b/test/key/processMIME.spec.ts
@@ -1,59 +1,102 @@
 import { expect } from 'chai';
 
-import processMIME from '../../lib/message/processMIME';
-import { getKeys } from '../../lib';
+import { getKeys, processMIME, utf8ArrayToString } from '../../lib';
 import { VERIFICATION_STATUS } from '../../lib/constants';
+import { Signature } from '../../lib/openpgp';
 import {
     invalidMultipartSignedMessage,
     multipartSignedMessage,
     multipartSignedMessageBody,
     extraMultipartSignedMessage,
     multiPartMessageWithSpecialCharacter,
+    multipartMessageWithAttachment,
+    multipartMessageWithEncryptedSubject,
     key
 } from './processMIME.data';
 
 describe('processMIME', () => {
     it('it can process multipart/signed mime messages and verify the signature', async () => {
-        const { body, verified } = await processMIME(
+        const { body, verified, signatures, attachments, encryptedSubject } = await processMIME(
             {
-                publicKeys: await getKeys(key)
+                verificationKeys: await getKeys(key)
             },
             multipartSignedMessage
         );
         expect(verified).to.equal(VERIFICATION_STATUS.SIGNED_AND_VALID);
+        expect(signatures.length).to.equal(1);
+        expect(signatures[0]).to.be.instanceOf(Signature);
         expect(body).to.equal(multipartSignedMessageBody);
+        expect(attachments.length).to.equal(0);
+        expect(encryptedSubject).to.equal('');
     });
 
     it('it can process multipart/signed mime messages and verify the signature with extra parts at the end', async () => {
-        const { body, verified } = await processMIME(
+        const { body, verified,signatures } = await processMIME(
             {
-                publicKeys: await getKeys(key)
+                verificationKeys: await getKeys(key)
             },
             extraMultipartSignedMessage
         );
         expect(verified).to.equal(VERIFICATION_STATUS.SIGNED_AND_VALID);
         expect(body).to.equal('hello');
+        expect(signatures.length).to.equal(1);
     });
 
     it('it does not verify invalid messages', async () => {
-        const { verified, body } = await processMIME(
+        const { verified, body, signatures } = await processMIME(
             {
-                publicKeys: await getKeys(key)
+                verificationKeys: await getKeys(key)
             },
             invalidMultipartSignedMessage
         );
         expect(verified).to.equal(VERIFICATION_STATUS.NOT_SIGNED);
+        expect(signatures.length).to.equal(0);
         expect(body).to.equal('message with missing signature');
     });
 
     it('it can parse messages with special characters in the boundary', async () => {
-        const { verified, body } = await processMIME(
+        const { verified, body, signatures } = await processMIME(
             {
-                publicKeys: await getKeys(key)
+                verificationKeys: await getKeys(key)
             },
             multiPartMessageWithSpecialCharacter
         );
         expect(verified).to.equal(VERIFICATION_STATUS.SIGNED_AND_VALID);
+        expect(signatures.length).to.equal(1);
+        expect(body).to.equal('hello');
+    });
+
+    it('it can parse message with text attachment', async () => {
+        const { verified, body, signatures, attachments } = await processMIME(
+            {
+                verificationKeys: await getKeys(key)
+            },
+            multipartMessageWithAttachment
+        );
+        expect(verified).to.equal(VERIFICATION_STATUS.NOT_SIGNED);
+        expect(signatures.length).to.equal(0);
+        expect(body).to.equal('this is the body text\n');
+        expect(attachments.length).to.equal(1);
+        const [attachment] = attachments;
+        expect(attachment.fileName).to.equal('test.txt');
+        expect(attachment.generatedFileName).to.equal('test.txt');
+        expect(attachment.contentType).to.equal('text/plain');
+        expect(attachment.contentDisposition).to.equal('attachment');
+        expect(attachment.checksum).to.equal('94ee2b41f2016f2ec79a7b3a2faf920e');
+        expect(attachment.content).to.be.instanceOf(Uint8Array);
+        expect(utf8ArrayToString(attachment.content)).to.equal('this is the attachment text\r\n')
+    });
+
+    it('it can parse message with encrypted subject', async () => {
+        const { verified, body, signatures, encryptedSubject } = await processMIME(
+            {
+                verificationKeys: await getKeys(key)
+            },
+            multipartMessageWithEncryptedSubject
+        );
+        expect(verified).to.equal(VERIFICATION_STATUS.SIGNED_AND_INVALID);
+        expect(signatures.length).to.equal(1);
+        expect(encryptedSubject).to.equal('Encrypted subject');
         expect(body).to.equal('hello');
     });
 });

--- a/test/key/processMIME.spec.ts
+++ b/test/key/processMIME.spec.ts
@@ -18,9 +18,9 @@ describe('processMIME', () => {
     it('it can process multipart/signed mime messages and verify the signature', async () => {
         const { body, verified, signatures, attachments, encryptedSubject } = await processMIME(
             {
+                data: multipartSignedMessage,
                 verificationKeys: await getKeys(key)
-            },
-            multipartSignedMessage
+            }
         );
         expect(verified).to.equal(VERIFICATION_STATUS.SIGNED_AND_VALID);
         expect(signatures.length).to.equal(1);
@@ -33,9 +33,9 @@ describe('processMIME', () => {
     it('it can process multipart/signed mime messages and verify the signature with extra parts at the end', async () => {
         const { body, verified,signatures } = await processMIME(
             {
+                data: extraMultipartSignedMessage,
                 verificationKeys: await getKeys(key)
-            },
-            extraMultipartSignedMessage
+            }
         );
         expect(verified).to.equal(VERIFICATION_STATUS.SIGNED_AND_VALID);
         expect(body).to.equal('hello');
@@ -45,9 +45,9 @@ describe('processMIME', () => {
     it('it does not verify invalid messages', async () => {
         const { verified, body, signatures } = await processMIME(
             {
+                data: invalidMultipartSignedMessage,
                 verificationKeys: await getKeys(key)
-            },
-            invalidMultipartSignedMessage
+            }
         );
         expect(verified).to.equal(VERIFICATION_STATUS.NOT_SIGNED);
         expect(signatures.length).to.equal(0);
@@ -57,9 +57,9 @@ describe('processMIME', () => {
     it('it can parse messages with special characters in the boundary', async () => {
         const { verified, body, signatures } = await processMIME(
             {
+                data: multiPartMessageWithSpecialCharacter,
                 verificationKeys: await getKeys(key)
-            },
-            multiPartMessageWithSpecialCharacter
+            }
         );
         expect(verified).to.equal(VERIFICATION_STATUS.SIGNED_AND_VALID);
         expect(signatures.length).to.equal(1);
@@ -67,12 +67,10 @@ describe('processMIME', () => {
     });
 
     it('it can parse message with text attachment', async () => {
-        const { verified, body, signatures, attachments } = await processMIME(
-            {
-                verificationKeys: await getKeys(key)
-            },
-            multipartMessageWithAttachment
-        );
+        const { verified, body, signatures, attachments } = await processMIME({
+            data: multipartMessageWithAttachment,
+            verificationKeys: await getKeys(key)
+        });
         expect(verified).to.equal(VERIFICATION_STATUS.NOT_SIGNED);
         expect(signatures.length).to.equal(0);
         expect(body).to.equal('this is the body text\n');
@@ -88,12 +86,10 @@ describe('processMIME', () => {
     });
 
     it('it can parse message with encrypted subject', async () => {
-        const { verified, body, signatures, encryptedSubject } = await processMIME(
-            {
-                verificationKeys: await getKeys(key)
-            },
-            multipartMessageWithEncryptedSubject
-        );
+        const { verified, body, signatures, encryptedSubject } = await processMIME({
+            data: multipartMessageWithEncryptedSubject,
+            verificationKeys: await getKeys(key)
+        });
         expect(verified).to.equal(VERIFICATION_STATUS.SIGNED_AND_INVALID);
         expect(signatures.length).to.equal(1);
         expect(encryptedSubject).to.equal('Encrypted subject');


### PR DESCRIPTION
Breaking changes to `processMIME`:
- drop second argument (`data`) and take `options.data` instead. This is to align the function interface with `encrypt/sign/verify/decryptMessage`.
- Rename `options.publicKeys` to `.verificationKeys` (follow up to #123).
- If no encrypted subject is found, `result.encryptedSubject` defaults to empty string instead of `false`. The app logic should be unaffected as `encryptedSubject` was already [declared](https://github.com/ProtonMail/WebClients/blob/d8cce0c430c3d51e3b611a53095ee6ce285594bc/applications/mail/src/app/helpers/message/messageDecrypt.ts#L38) and [treated](https://github.com/ProtonMail/WebClients/blob/35c0972864b13b54dd0be88dd84b5a1692f2d0e4/applications/mail/src/app/components/message/extras/ExtraDecryptedSubject.tsx) as a string in all cases.
- If the message does not have a body, the result now includes the fields `body: ''` and `mimetype: undefined` fields. Before, the fields were omitted. The change is again inline with the existing [webapp types](https://github.com/ProtonMail/WebClients/blob/d8cce0c430c3d51e3b611a53095ee6ce285594bc/applications/mail/src/app/helpers/message/messageDecrypt.ts#L57).

Also:
- `options.sender` defaults to empty string instead of `null` (otherwise the function would break in [this edge case](https://github.com/ProtonMail/pmcrypto/compare/v7...larabr:ts-processMIME?expand=1#diff-750da7b8a89bd39d114d6616655f302fa655511a4bc324d03a957decc6a1e5e2R118))
- default `options.date` to `serverTime()`
- add tests for MIME messages with attachment and encrypted subject;
- add TS definitions for `processMIME`