### PR TITLE
[v7] Add `verifyCleartextMessage`

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -14,7 +14,8 @@ import {
     PublicKey,
     SessionKey,
     encryptSessionKey,
-    WebStream
+    WebStream,
+    CleartextMessage
 } from 'openpgp/lightweight';
 
 export function init(): void;
@@ -270,6 +271,14 @@ export interface VerifyMessageResult {
     errors?: Error[];
 }
 export function verifyMessage(options: VerifyOptionsPmcrypto): Promise<VerifyMessageResult>;
+
+export interface VerifyCleartextOptionsPmcrypto extends Omit<VerifyOptions, 'message' | 'signature' | 'format'> {
+    cleartextMessage: CleartextMessage
+}
+// Cleartext message data is always of utf8 format
+export function verifyCleartextMessage(
+    options: VerifyCleartextOptionsPmcrypto
+): Promise<VerifyMessageResult>;
 
 export interface ProcessMIMEOptions {
     data: string,

--- a/lib/message/utils.js
+++ b/lib/message/utils.js
@@ -208,6 +208,46 @@ export async function verifyMessage({ textData, binaryData, stripTrailingSpaces,
         });
 }
 
+/**
+ * Verify the given Cleartext message, which includes both the data to verify and the corresponding signature.
+ * To verify a detached signature over some data, see `verifyMessage` instead.
+ * @param  {Object}                      options - input for openpgp.verify
+ * @param  {openpgp.CleartextMessage}    cleartextMessage - signed armored cleartext message
+ * @param  {Date}                        [options.date] date to use for verification instead of the server time
+ *
+ * @returns {Promise<Object>}  Verification result in the form: {
+ *     data: Uint8Array|string|ReadableStream - message data,
+ *     verified: constants.VERIFICATION_STATUS - message verification status,
+ *     signatures: openpgp.Signature[] - message signatures,
+ *     signatureTimestamp: Date|null - creation date of the first valid message signature, or null if all signatures are missing or invalid,
+ *     errors: Error[]|undefined - verification errors if all signatures are invalid
+ * }
+ */
+ export async function verifyCleartextMessage({ cleartextMessage, date = serverTime(), ...options }) {
+    if (!(cleartextMessage instanceof CleartextMessage)) {
+        throw new Error('CleartextMessage expected.')
+    }
+    const sanitizedOptions = {
+        ...options,
+        date,
+        message: cleartextMessage
+    };
+
+    return verify(sanitizedOptions)
+        .then(handleVerificationResult)
+        .then(({ data, verified, signatureTimestamp, signatures, errors }) => ({
+            data,
+            verified,
+            signatureTimestamp,
+            signatures,
+            errors
+        }))
+        .catch((err) => {
+            console.error(err);
+            return Promise.reject(err);
+        });
+}
+
 export async function splitMessage(message) {
     const msg = await getMessage(message);
 

--- a/lib/pmcrypto.js
+++ b/lib/pmcrypto.js
@@ -55,6 +55,7 @@ export {
     signMessage,
     splitMessage,
     verifyMessage,
+    verifyCleartextMessage,
     getCleartextMessage,
     armorBytes
 } from './message/utils';


### PR DESCRIPTION
This is needed for SRP modulus verification, since the modulus is given as cleartext message.