### PR TITLE
Set `allowInsecureVerificationWithReformattedKeys` in global config

### DIFF
--- a/lib/openpgp.d.ts
+++ b/lib/openpgp.d.ts
@@ -1,2 +1,0 @@
-export * from 'openpgp/lightweight';
-export function setConfig(): void;

--- a/lib/openpgp.ts
+++ b/lib/openpgp.ts
@@ -9,6 +9,12 @@ export const setConfig = () => {
      */
     config.allowInsecureDecryptionWithSigningKeys = true;
 
+    /**
+     * This is necessary as we used to reformat keys on import, without setting the new binding signature creation time
+     * to match the key creation time.
+     */
+    config.allowInsecureVerificationWithReformattedKeys = true;
+
     // these minimum key settings apply to already imported (private) keys as well, so we cannot be too strict.
     // to enforce stricter checks e.g. on new key imports, `checkKeyStrength` should be called.
     config.rejectPublicKeyAlgorithms = new Set();


### PR DESCRIPTION
TODO:
- [x] point to released OpenPGP.js patch (for fixed TS definition)