### PR TITLE
Run tests in Firefox and Webkit if installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,8 +157,8 @@ const sessionKey = await decryptSessionKey({
 </details>
 
 ## Testing
-Headless Chrome is used for the tests.
-With Chrome installed, running `npm test` should work out of the box.
+Headless Chrome, Firefox and Webkit are used for the tests (if installed).
+With any of the browsers installed, running `npm test` should work out of the box.
 To use a different Chromium-based browser, set the environment variable `CHROME_BIN` to point to the corresponding executable.
 
 

--- a/circle.yml
+++ b/circle.yml
@@ -7,6 +7,7 @@ jobs:
             - image: cimg/node:lts-browsers
         steps:
             - browser-tools/install-chrome
+            - browser-tools/install-firefox
             - checkout
             - run: npm i
             - run: npm run lint

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -5,9 +5,17 @@ module.exports = function(config) {
 
         // frameworks to use
         // available frameworks: https://www.npmjs.com/search?q=keywords:karma-adapter
-        frameworks: ['mocha', 'webpack'],
+        frameworks: ['mocha', 'webpack', 'detectBrowsers'],
 
-        plugins: ['karma-mocha', 'karma-chrome-launcher', 'karma-webpack', 'karma-mocha-reporter'],
+        plugins: [
+            'karma-mocha',
+            'karma-webpack',
+            'karma-mocha-reporter',
+            'karma-detect-browsers', // skip tests on browsers that are not installed
+            'karma-chrome-launcher',
+            'karma-firefox-launcher',
+            'karma-webkit-launcher'
+        ],
 
         // list of files / patterns to load in the browser
         files: [{ pattern: 'test/**/*.*', watched: false }],
@@ -50,9 +58,17 @@ module.exports = function(config) {
         // enable / disable watching file and executing tests whenever any file changes
         autoWatch: false,
 
-        // start these browsers
-        // available browser launchers: https://www.npmjs.com/search?q=keywords:karma-launcher
-        browsers: ['ChromeHeadless'],
+        detectBrowsers: {
+            usePhantomJS: false,
+            // use headless mode, for browsers that support it, default is false
+            preferHeadless: true,
+
+            // post processing of browsers list
+            postDetection: (availableBrowsers) => {
+                const testableBrowsers = new Set(['ChromeHeadless', 'FirefoxHeadless', 'WebkitHeadless']);
+                return availableBrowsers.filter((browser) => testableBrowsers.has(browser));
+            }
+        },
 
         // Continuous Integration mode
         // if true, Karma captures browsers, runs the tests and exits
@@ -67,6 +83,6 @@ module.exports = function(config) {
                 // timeout for mocha tests, default is 2 seconds. Some streaming tests can take longer.
                 timeout : 12000
             }
-          }
+        }
     });
 };

--- a/package.json
+++ b/package.json
@@ -29,6 +29,9 @@
         "@openpgp/asmcrypto.js": "^2.3.2",
         "@openpgp/tweetnacl": "^1.0.3",
         "@openpgp/web-stream-tools": "^0.0.10",
+        "karma-detect-browsers": "^2.3.3",
+        "karma-firefox-launcher": "^2.1.2",
+        "karma-webkit-launcher": "^1.0.2",
         "openpgp": "npm:@protontech/openpgp@~5.3.0"
     },
     "devDependencies": {


### PR DESCRIPTION
No Safari because it cannot run in headless mode, and prompts the user for confirmation whenever the tests are started.