### PR TITLE
Export `removeTrailingSpaces()` as part of utils

### DIFF
--- a/lib/message/encrypt.js
+++ b/lib/message/encrypt.js
@@ -1,7 +1,7 @@
 import { isStream, passiveClone, clone } from '@openpgp/web-stream-tools';
 import { generateSessionKey, encrypt, sign, createMessage, armor as openpgp_armor, enums } from '../openpgp';
 import { serverTime } from '../serverTime';
-import { removeTrailingSpaces } from './utils';
+import { removeTrailingSpaces } from '../utils';
 
 export default async function encryptMessage({
     textData,

--- a/lib/message/processMIME.js
+++ b/lib/message/processMIME.js
@@ -1,4 +1,4 @@
-import { removeTrailingSpaces } from './utils';
+import { removeTrailingSpaces } from '../utils';
 import { verifyMessage } from './verify';
 import { VERIFICATION_STATUS, MAX_ENC_HEADER_LENGTH } from '../constants';
 import { serverTime } from '../serverTime';

--- a/lib/message/sign.js
+++ b/lib/message/sign.js
@@ -1,6 +1,6 @@
 import { createMessage, sign } from '../openpgp';
 import { serverTime } from '../serverTime';
-import { removeTrailingSpaces } from './utils';
+import { removeTrailingSpaces } from '../utils';
 
 /**
  * Get a signed message from the given data.

--- a/lib/message/utils.ts
+++ b/lib/message/utils.ts
@@ -9,20 +9,6 @@ import {
 } from '../openpgp';
 import type { OpenPGPMessage } from '../pmcrypto';
 
-/**
- * Remove trailing spaces, carriage returns and tabs from each line (separated by \n characters)
- */
-export const removeTrailingSpaces = (text: string) => {
-    return text
-        .split('\n')
-        .map((line) => {
-            let i = line.length - 1;
-            for (; i >= 0 && (line[i] === ' ' || line[i] === '\t' || line[i] === '\r'); i--);
-            return line.substring(0, i + 1);
-        })
-        .join('\n');
-};
-
 export async function splitMessage(message: OpenPGPMessage) {
     const keyFilter = (packet: AnyPacket) => {
         const packetTag = (packet.constructor as typeof OpenPGPPacket).tag;

--- a/lib/message/verify.js
+++ b/lib/message/verify.js
@@ -1,7 +1,7 @@
 import { createMessage, verify, CleartextMessage } from '../openpgp';
 import { VERIFICATION_STATUS } from '../constants';
 import { serverTime } from '../serverTime';
-import { removeTrailingSpaces } from './utils';
+import { removeTrailingSpaces } from '../utils';
 
 const { NOT_SIGNED, SIGNED_AND_VALID, SIGNED_AND_INVALID } = VERIFICATION_STATUS;
 

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -175,3 +175,17 @@ export function utf8ArrayToString(utf8: MaybeStream<Uint8Array>): MaybeStream<st
 
     return transformedStream;
 }
+
+/**
+ * Remove trailing spaces, carriage returns and tabs from each line (separated by \n characters)
+ */
+export const removeTrailingSpaces = (text: string) => {
+    return text
+        .split('\n')
+        .map((line) => {
+            let i = line.length - 1;
+            for (; i >= 0 && (line[i] === ' ' || line[i] === '\t' || line[i] === '\r'); i--);
+            return line.substring(0, i + 1);
+        })
+        .join('\n');
+};

--- a/test/message/utils.spec.ts
+++ b/test/message/utils.spec.ts
@@ -1,7 +1,6 @@
 import { expect } from 'chai';
 import { PublicKeyEncryptedSessionKeyPacket, AEADEncryptedDataPacket } from '../../lib/openpgp';
 import { stripArmor, splitMessage, armorBytes, readMessage } from '../../lib';
-import { removeTrailingSpaces } from '../../lib/message/utils';
 
 describe('message utils', () => {
     it('stripArmor - it can correctly dearmor a message', async () => {
@@ -65,11 +64,5 @@ sJFJxllC0j4wHCOS9uiSYsZ/pWCqxX/3sFh4VBFOpr0HAA==
         expect(pkesk.packets[0]).to.be.instanceOf(PublicKeyEncryptedSessionKeyPacket);
         const aeadData = await readMessage({ binaryMessage: packets.encrypted[0] });
         expect(aeadData.packets[0]).to.be.instanceOf(AEADEncryptedDataPacket);
-    });
-
-    it('removeTrailingSpaces - it can correctly normalise the text', async () => {
-        const data = 'BEGIN:VCARD\r\nVERSION:4.0\r\nFN;PREF=1:   \r\nEND:VCARD';
-        const expected = 'BEGIN:VCARD\nVERSION:4.0\nFN;PREF=1:\nEND:VCARD';
-        expect(removeTrailingSpaces(data)).to.equal(expected);
     });
 });

--- a/test/utils.spec.ts
+++ b/test/utils.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 // @ts-ignore missing isStream definitions
 import { isStream, readToEnd } from '@openpgp/web-stream-tools';
-import { concatArrays, decodeBase64, encodeBase64, hexStringToArray, stringToUtf8Array, utf8ArrayToString } from '../lib/utils';
+import { concatArrays, decodeBase64, encodeBase64, hexStringToArray, removeTrailingSpaces, stringToUtf8Array, utf8ArrayToString } from '../lib/utils';
 import type { Data } from '../lib';
 
 const streamFromChunks = <T extends Data>(chunks: T[]) => {
@@ -79,5 +79,11 @@ describe('utils', () => {
 
     it('decodeBase64 - it can correctly decode base 64', async () => {
         expect(decodeBase64('Zm9v')).to.equal('foo');
+    });
+
+    it('removeTrailingSpaces - it can correctly normalise the text', async () => {
+        const data = 'BEGIN:VCARD\r\nVERSION:4.0\r\nFN;PREF=1:   \r\nEND:VCARD';
+        const expected = 'BEGIN:VCARD\nVERSION:4.0\nFN;PREF=1:\nEND:VCARD';
+        expect(removeTrailingSpaces(data)).to.equal(expected);
     });
 });


### PR DESCRIPTION
To be importable by the apps, as it's needed for implementing fallback verification following the fix in #151