### PR TITLE
`decryptMessageLegacy`: pass down `config` as part of legacy options

### DIFF
--- a/lib/message/decryptLegacy.js
+++ b/lib/message/decryptLegacy.js
@@ -63,7 +63,8 @@ export default async function decryptMessageLegacy({ messageDate, armoredMessage
     // Legacy message encryption format
     const legacyOptions = {
         decryptionKeys,
-        message: await readMessage({ armoredMessage: oldEncRandomKey })
+        message: await readMessage({ armoredMessage: oldEncRandomKey }),
+        config: options.config
     };
 
     const { data, verificationErrors } = await decryptMessage(legacyOptions);


### PR DESCRIPTION
This is needed to enable constant-time decryption during the legacy migration process.