### PR TITLE
`processMIME`: fix decoding of non-ASCII subjects

### DIFF
--- a/lib/message/processMIME.ts
+++ b/lib/message/processMIME.ts
@@ -127,13 +127,7 @@ const parse = async (
         if (!attachmentSubject || !from) {
             continue;
         }
-        const fromEmail = from
-            .split('<')
-            .pop()
-            ?.replace('>', '')
-            .trim()
-            .toLowerCase() || '';
-        if (fromEmail !== sender.toLowerCase()) {
+        if (from.email.toLowerCase() !== sender.toLowerCase()) {
             continue;
         }
         // found the encrypted subject:

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
                 "@openpgp/asmcrypto.js": "^2.3.3-0",
                 "@openpgp/tweetnacl": "^1.0.3",
                 "@openpgp/web-stream-tools": "^0.0.13",
-                "jsmimeparser": "npm:@protontech/jsmimeparser@^1.0.4",
+                "jsmimeparser": "npm:@protontech/jsmimeparser@^2.0.1",
                 "openpgp": "npm:@protontech/openpgp@~5.5.0"
             },
             "devDependencies": {
@@ -3257,9 +3257,9 @@
         },
         "node_modules/jsmimeparser": {
             "name": "@protontech/jsmimeparser",
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/@protontech/jsmimeparser/-/jsmimeparser-1.0.4.tgz",
-            "integrity": "sha512-oFrGeISVPANkdPt3p3SDbhhv3vgUqwbtWJuHJW+Ma+mpYTtg8Q9qD0aEHNrQOZ1/h030mvhR3LNOAKeU4c33WA=="
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@protontech/jsmimeparser/-/jsmimeparser-2.0.1.tgz",
+            "integrity": "sha512-FBT3sT1pm+fDjHBbnbmjsLo4SN77FHQOUT9ZylDbzYILBBpAQh3o4ghPWtkl72zEtlDyOgVUq5DboxNakbklGA=="
         },
         "node_modules/json-parse-better-errors": {
             "version": "1.0.2",
@@ -7954,9 +7954,9 @@
             }
         },
         "jsmimeparser": {
-            "version": "npm:@protontech/jsmimeparser@1.0.4",
-            "resolved": "https://registry.npmjs.org/@protontech/jsmimeparser/-/jsmimeparser-1.0.4.tgz",
-            "integrity": "sha512-oFrGeISVPANkdPt3p3SDbhhv3vgUqwbtWJuHJW+Ma+mpYTtg8Q9qD0aEHNrQOZ1/h030mvhR3LNOAKeU4c33WA=="
+            "version": "npm:@protontech/jsmimeparser@2.0.1",
+            "resolved": "https://registry.npmjs.org/@protontech/jsmimeparser/-/jsmimeparser-2.0.1.tgz",
+            "integrity": "sha512-FBT3sT1pm+fDjHBbnbmjsLo4SN77FHQOUT9ZylDbzYILBBpAQh3o4ghPWtkl72zEtlDyOgVUq5DboxNakbklGA=="
         },
         "json-parse-better-errors": {
             "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
         "@openpgp/asmcrypto.js": "^2.3.3-0",
         "@openpgp/tweetnacl": "^1.0.3",
         "@openpgp/web-stream-tools": "^0.0.13",
-        "jsmimeparser": "npm:@protontech/jsmimeparser@^1.0.4",
+        "jsmimeparser": "npm:@protontech/jsmimeparser@^2.0.1",
         "openpgp": "npm:@protontech/openpgp@~5.5.0"
     },
     "devDependencies": {

--- a/test/message/processMIME.data.ts
+++ b/test/message/processMIME.data.ts
@@ -221,3 +221,56 @@ Content-Disposition: attachment;
 this is the second attachment text
 
 --XXXXboundary text--`;
+
+// NB: this message signature is invalid and not verifiable using `key`.
+export const multipartMessageWithEncryptedSubjectUTF8 = `Content-Type: multipart/signed; micalg=pgp-sha256;
+ protocol="application/pgp-signature";
+ boundary="------------3mBgKY4DhzDe0cOovVcT4QQv"
+
+This is an OpenPGP/MIME signed message (RFC 4880 and 3156)
+--------------3mBgKY4DhzDe0cOovVcT4QQv
+Content-Type: multipart/mixed; boundary="------------7VgK7B2dk0pUYjHBY0Zi2Fda";
+ protected-headers="v1"
+Subject: =?UTF-8?B?c3ViamVjdCB3aXRoIGVtb2ppcyDwn5iD8J+Yhw==?=
+From: Sender <sender@example.com>
+To: receiver@example.com
+Message-ID: <7daafa18-8595-8065-3eba-b08c07becf36@example.com>
+
+--------------7VgK7B2dk0pUYjHBY0Zi2Fda
+Content-Type: multipart/mixed; boundary="------------D5jH01SvFZAwYShsjQamYW8w"
+
+--------------D5jH01SvFZAwYShsjQamYW8w
+Content-Type: text/plain; charset=UTF-8; format=flowed
+Content-Transfer-Encoding: base64
+
+dGVzdCB1dGY4IGluIGVuY3J5cHRlZCBzdWJqZWN0DQo=
+--------------D5jH01SvFZAwYShsjQamYW8w
+Content-Type: application/pgp-keys; name="OpenPGP_0xabc.asc"
+Content-Disposition: attachment; filename="OpenPGP_0xabc.asc"
+Content-Description: OpenPGP public key
+Content-Transfer-Encoding: quoted-printable
+
+-----BEGIN PGP PUBLIC KEY BLOCK-----
+
+...
+-----END PGP PUBLIC KEY BLOCK-----
+
+--------------D5jH01SvFZAwYShsjQamYW8w--
+
+--------------7VgK7B2dk0pUYjHBY0Zi2Fda--
+
+--------------3mBgKY4DhzDe0cOovVcT4QQv
+Content-Type: application/pgp-signature; name="OpenPGP_signature.asc"
+Content-Description: OpenPGP digital signature
+Content-Disposition: attachment; filename="OpenPGP_signature"
+
+-----BEGIN PGP SIGNATURE-----
+
+wnUEARYKAAYFAmIwlfMAIQkQdqGsuYvE1jgWIQRGvajOG9a8ZbdysiN2oay5
+i8TWOBX5AP0V5H79/eiraXKKBCvpqwcEzrv1DHfhvrjTHk9L6PIadgD/fXdv
+WTyjgksKkPV68HhW1CIKZ4JIMe726uldjP6tgw8=
+=nHao
+-----END PGP SIGNATURE-----
+
+--------------3mBgKY4DhzDe0cOovVcT4QQv--
+`;

--- a/test/message/processMIME.spec.ts
+++ b/test/message/processMIME.spec.ts
@@ -13,7 +13,8 @@ import {
     multipartMessageWithAttachment,
     multipartMessageWithEncryptedSubject,
     key,
-    multipartMessageWithUnnamedAttachments
+    multipartMessageWithUnnamedAttachments,
+    multipartMessageWithEncryptedSubjectUTF8
 } from './processMIME.data';
 
 describe('processMIME', () => {
@@ -105,5 +106,14 @@ describe('processMIME', () => {
         expect(attachments[0].fileName).to.equal('attachment.txt');
         expect(attachments[1].fileName).to.equal('attachment.txt (1)');
         expect(attachments[0].contentId).to.not.equal(attachments[1].contentId);
+    });
+
+    it('it can parse message with encrypted subject containing non-ASCII chars', async () => {
+        const { body, encryptedSubject } = await processMIME({
+            data: multipartMessageWithEncryptedSubjectUTF8,
+            verificationKeys: []
+        });
+        expect(encryptedSubject).to.equal('subject with emojis 😃😇');
+        expect(body).to.equal('test utf8 in encrypted subject\n');
     });
 });


### PR DESCRIPTION
Support was broken in #157 , since jsmimeparser did not process the returned header values. As a result, subject containing non-ASCII chars (e.g. emojis) were not decoded.
This PR updates the lib to a new version that takes care of decoding the returned data.