### PR TITLE
Add context support (domain separation for signatures)

### DIFF
--- a/lib/message/context.ts
+++ b/lib/message/context.ts
@@ -1,0 +1,102 @@
+/**
+ * The context is an abstraction we use to add domain separation to OpenPGP signatures.
+ * It's implemented by adding notation data to signatures, which may be marked as critical, so that
+ * the resulting signature can only be verified by a verifier who expects the context to be present.
+ */
+import { SignaturePacket, RawNotation, PartialConfig } from '../openpgp';
+import { normalizeDate } from './utils';
+
+// Different contexts will affect the notation's value, not the name
+const CONTEXT_NOTATION_NAME = 'context@proton.ch';
+
+export interface ContextSigningOptions {
+    /** context identifier */
+    value: string,
+    /**
+     * Whether verification must fail unless the verifier is context-aware:
+     * if `true`, the signature cannot be verified unless the verifier expects the same context.
+     * If `false`, the signature will verify successfully even if the verifier does not expect any context.
+     * This should be set to `true` as long as all clients verifying the signature are able to process contexts.
+     */
+    critical: boolean
+}
+
+export type ContextVerificationOptions = {
+    value: string,
+    /**
+     * Whether the signature must include context info for verification to succeed:
+     * if `true`, a signature with no context won't verify. If `false`, it will.
+     * Note: if the context is not required, but a different context is found in the signature, verification will always fail.
+     */
+    required: boolean,
+    requiredAfter?: undefined
+} | {
+    value: string,
+    required?: undefined
+    /**
+     * Signatures created after this date must include context info for verification to succeed (same as `required: true`).
+     * For signatures created before the given date, the verification behavior is equivalent to `required: false`
+     * */
+    requiredAfter: Date,
+};
+
+/**
+ * Translate a `contextID` string into an OpenPGP notation object, which can be signed as part of the message
+ * @param contextValue - context identifier
+ * @param critical - whether the notation should be critical (if so, verification will fail if in the wrong context,
+ *  i.e. if the caller did not declare the notation as known)
+ */
+export const getNotationForContext = (contextValue: string, critical: boolean): RawNotation => ({
+    name: CONTEXT_NOTATION_NAME,
+    value: new TextEncoder().encode(contextValue),
+    humanReadable: true,
+    critical
+});
+
+/**
+ * Confirm context validity by finding the corresponding signature notation.
+ * NB: signature validity is not checked.
+ */
+export const isValidSignatureContext = (contextOptions: ContextVerificationOptions, signature: SignaturePacket) => {
+    const { value: expectedValue, required, requiredAfter } = contextOptions;
+    const isContextRequired = requiredAfter ? signature.created! >= normalizeDate(requiredAfter) : !!required;
+
+    // `rawNotations` are always hashed (i.e. signed), otherwise OpenPGP's ignores them on parsing
+    const contextNotations = signature.rawNotations.filter(({ name }) => (name === CONTEXT_NOTATION_NAME));
+    const matchingContext = contextNotations.find(({ value }) => (new TextDecoder().decode(value) === expectedValue));
+
+    if (matchingContext) {
+        return true;
+    } else if (contextNotations.length > 0) {
+        // mismatching context is present
+        return false;
+    }
+
+    // no context info found
+    return !isContextRequired;
+
+};
+
+/**
+ * Signatures with critical context data can only be verified with a config that declares the context notation data as known
+ */
+export const getConfigForContextVerification = (config: PartialConfig) => ({
+    ...config,
+    knownNotations: [CONTEXT_NOTATION_NAME] // we can overwrite the field as we currently don't use any other known notations
+});
+
+/**
+ * Context verification error.
+ * Thrown if e.g. context information is not present in the signature, or it does not match the expected context.
+ */
+export class ContextError extends Error {
+    constructor(...params: any[]) {
+        super(...params);
+
+        if (Error.captureStackTrace) {
+            Error.captureStackTrace(this, ContextError);
+        }
+
+        this.name = 'ContextError';
+    }
+}

--- a/lib/message/decrypt.js
+++ b/lib/message/decrypt.js
@@ -1,10 +1,17 @@
 import { isStream, readToEnd } from '@openpgp/web-stream-tools';
 import { decrypt, readSignature } from '../openpgp';
 import { serverTime } from '../serverTime';
+import { getConfigForContextVerification } from './context';
 import { handleVerificationResult } from './verify';
 
-export default async function decryptMessage({ date = serverTime(), encryptedSignature, ...options }) {
-    const sanitizedOptions = { ...options, date };
+export default async function decryptMessage({
+    date = serverTime(), encryptedSignature, context, config = {}, ...options
+}) {
+    const sanitizedOptions = {
+        ...options,
+        date,
+        config: context ? getConfigForContextVerification(config) : config
+    };
 
     try {
         // If encryptedSignature exists, decrypt and use it
@@ -18,7 +25,7 @@ export default async function decryptMessage({ date = serverTime(), encryptedSig
         }
 
         const decryptionResult = await decrypt(sanitizedOptions);
-        const verificationResult = handleVerificationResult(decryptionResult);
+        const verificationResult = handleVerificationResult(decryptionResult, context);
 
         let verified = verificationResult.then((result) => result.verified);
         let verifiedSignatures = verificationResult.then((result) => result.signatures);

--- a/lib/message/encrypt.js
+++ b/lib/message/encrypt.js
@@ -2,17 +2,24 @@ import { isStream, passiveClone, clone } from '@openpgp/web-stream-tools';
 import { generateSessionKey, encrypt, sign, createMessage, armor as openpgp_armor, enums } from '../openpgp';
 import { serverTime } from '../serverTime';
 import { removeTrailingSpaces } from './utils';
+import { getNotationForContext } from './context';
 
 export default async function encryptMessage({
     textData,
     binaryData,
     stripTrailingSpaces,
+    context,
     format = 'armored',
     date = serverTime(),
     detached = false,
     ...options
 }) {
-    const sanitizedOptions = { ...options, date, format };
+    const sanitizedOptions = {
+        ...options,
+        signatureNotations: context ? getNotationForContext(context.value, context.critical) : undefined, // only applied if signingKeys are given
+        date,
+        format
+    };
     const dataType = binaryData ? 'binary' : 'text';
     const data = binaryData || (stripTrailingSpaces ? removeTrailingSpaces(textData) : textData); // throw if streamed text and stripTrailingSpaces enabled
 
@@ -42,6 +49,7 @@ export default async function encryptMessage({
             signingKeys: sanitizedOptions.signingKeys,
             signingKeyIDs: sanitizedOptions.signingKeyIDs,
             signingUserIDs: sanitizedOptions.signingUserIDs,
+            signatureNotations: sanitizedOptions.signatureNotations,
             date: sanitizedOptions.date,
             config: sanitizedOptions.config,
             format: 'binary',

--- a/lib/message/encrypt.js
+++ b/lib/message/encrypt.js
@@ -50,6 +50,7 @@ export default async function encryptMessage({
 
         result.encryptedSignature = await encrypt({
             ...sanitizedOptions,
+            signingKeys: [],
             message: await createMessage({ binary: clone(detachedSignatureBinary), date }) // clone is very cheap for non-stream binary data (it just returns a subarray)
         });
 

--- a/lib/message/sign.js
+++ b/lib/message/sign.js
@@ -1,5 +1,6 @@
 import { createMessage, sign } from '../openpgp';
 import { serverTime } from '../serverTime';
+import { getNotationForContext } from './context';
 import { removeTrailingSpaces } from './utils';
 
 /**
@@ -16,6 +17,7 @@ export default async function signMessage({
     textData,
     binaryData,
     stripTrailingSpaces,
+    context,
     date = serverTime(),
     format = 'armored',
     ...options
@@ -26,7 +28,8 @@ export default async function signMessage({
         ...options,
         date,
         format,
-        message: await createMessage({ [dataType]: data, date })
+        message: await createMessage({ [dataType]: data, date }),
+        signatureNotations: context ? getNotationForContext(context.value, context.critical) : undefined
     };
 
     return sign(sanitizedOptions).catch((err) => {

--- a/lib/message/utils.ts
+++ b/lib/message/utils.ts
@@ -94,3 +94,10 @@ export const stripArmor = async (input: string) => {
     const bytes = await readToEnd(data);
     return bytes;
 };
+
+/**
+ * Normalise date to compare it to other OpenPGP timestamps
+ * @param time - date to normalise
+ * @returns date with reduced precision (seconds)
+ */
+export const normalizeDate = (time: Date) => new Date(Math.floor(+time / 1000) * 1000);

--- a/lib/message/verify.d.ts
+++ b/lib/message/verify.d.ts
@@ -7,12 +7,14 @@ import type {
     Signature as OpenPGPSignature
 } from 'openpgp/lightweight';
 import { VERIFICATION_STATUS } from '../constants';
+import { ContextVerificationOptions } from './context';
 
 // Streaming not supported when verifying detached signatures
 export interface VerifyOptionsPmcrypto<T extends Data> extends Omit<VerifyOptions, 'message'> {
     textData?: T extends string ? T : never;
     binaryData?: T extends Uint8Array ? T : never;
     stripTrailingSpaces?: T extends string ? boolean : never;
+    context?: ContextVerificationOptions;
 }
 
 export interface VerifyMessageResult<DataType extends openpgp_VerifyMessageResult['data'] = Data> {

--- a/lib/message/verify.js
+++ b/lib/message/verify.js
@@ -18,7 +18,6 @@ const { NOT_SIGNED, SIGNED_AND_VALID, SIGNED_AND_INVALID } = VERIFICATION_STATUS
  *         }
  * @returns {{
  *     data: Uint8Array|string|ReadableStream|NodeStream - message data,
- *     filename: String,
  *     verified: constants.VERIFICATION_STATUS - message verification status,
  *     signatures: openpgp.signature.Signature[] - message signatures,
  *     signatureTimestamp: Date|null - creation date of the first valid message signature, or null if all signatures are missing or invalid,
@@ -59,7 +58,6 @@ export async function handleVerificationResult({ data, filename = 'msg.txt', sig
     return {
         data,
         verified: verificationStatus,
-        filename,
         signatures,
         signatureTimestamp,
         errors: verificationStatus === SIGNED_AND_INVALID ? errors : undefined
@@ -91,15 +89,7 @@ export async function verifyMessage({ textData, binaryData, stripTrailingSpaces,
         message: await createMessage({ [dataType]: dataToVerify, date })
     };
 
-    return verify(sanitizedOptions)
-        .then(handleVerificationResult)
-        .then(({ data, verified, signatureTimestamp, signatures, errors }) => ({
-            data,
-            verified,
-            signatureTimestamp,
-            signatures,
-            errors
-        }));
+    return verify(sanitizedOptions).then(handleVerificationResult);
 }
 
 /**
@@ -127,13 +117,5 @@ export async function verifyCleartextMessage({ cleartextMessage, date = serverTi
         message: cleartextMessage
     };
 
-    return verify(sanitizedOptions)
-        .then(handleVerificationResult)
-        .then(({ data, verified, signatureTimestamp, signatures, errors }) => ({
-            data,
-            verified,
-            signatureTimestamp,
-            signatures,
-            errors
-        }));
+    return verify(sanitizedOptions).then(handleVerificationResult);
 }

--- a/lib/message/verify.js
+++ b/lib/message/verify.js
@@ -2,6 +2,7 @@ import { createMessage, verify, CleartextMessage } from '../openpgp';
 import { VERIFICATION_STATUS } from '../constants';
 import { serverTime } from '../serverTime';
 import { removeTrailingSpaces } from './utils';
+import { ContextError, getConfigForContextVerification, isValidSignatureContext } from './context';
 
 const { NOT_SIGNED, SIGNED_AND_VALID, SIGNED_AND_INVALID } = VERIFICATION_STATUS;
 
@@ -16,6 +17,7 @@ const { NOT_SIGNED, SIGNED_AND_VALID, SIGNED_AND_INVALID } = VERIFICATION_STATUS
  *           verified: Promise<Boolean>,
  *           signature: Promise<openpgp.signature.Signature>
  *         }
+ * @param {Object} context - context verification options
  * @returns {{
  *     data: Uint8Array|string|ReadableStream|NodeStream - message data,
  *     verified: constants.VERIFICATION_STATUS - message verification status,
@@ -24,7 +26,8 @@ const { NOT_SIGNED, SIGNED_AND_VALID, SIGNED_AND_INVALID } = VERIFICATION_STATUS
  *     errors: Error[]|undefined - verification errors if all signatures are invalid
  * }}
  */
-export async function handleVerificationResult({ data, filename = 'msg.txt', signatures: sigsInfo }) {
+export async function handleVerificationResult(verificationResult, context) {
+    const { data, signatures: sigsInfo } = verificationResult;
     const signatures = [];
     const errors = [];
     let verificationStatus = NOT_SIGNED;
@@ -40,13 +43,18 @@ export async function handleVerificationResult({ data, filename = 'msg.txt', sig
                 return false;
             });
             if (verified) {
-                verificationStatus = SIGNED_AND_VALID;
-
                 // In the context of message verification, signatures can only hold a single
                 // packet. Thus we do not need to iterate over the packets and find the one
                 // that verified the message. We can just use the single packet in the
                 // signature.
                 const verifiedSigPacket = signature.packets[0];
+
+                if (!context || isValidSignatureContext(context, verifiedSigPacket)) {
+                    verificationStatus = SIGNED_AND_VALID;
+                } else {
+                    errors.push(new ContextError());
+                }
+
                 if (!signatureTimestamp) {
                     signatureTimestamp = verifiedSigPacket.created;
                 }
@@ -69,7 +77,6 @@ export async function handleVerificationResult({ data, filename = 'msg.txt', sig
  * @param  {Object}                        options - input for openpgp.verify
  * @param  {String|ReadableStream<String>}  textData - sgined text data
  * @param  {Uint8Array|ReadableStream<Uint8Array>} binaryData - signed binary data
- * @param  {openpgp.Signature} options.signature - detached signature to verify
  * @param  {Date}                        [options.date] date to use for verification instead of the server time
  *
  * @returns {Promise<Object>}  Verification result in the form: {
@@ -80,16 +87,26 @@ export async function handleVerificationResult({ data, filename = 'msg.txt', sig
  *     errors: Error[]|undefined - verification errors if all signatures are invalid
  * }
  */
-export async function verifyMessage({ textData, binaryData, stripTrailingSpaces, date = serverTime(), ...options }) {
+export async function verifyMessage({
+    textData,
+    binaryData,
+    stripTrailingSpaces,
+    context,
+    config = {},
+    date = serverTime(),
+    ...options
+}) {
     const dataType = binaryData ? 'binary' : 'text';
     const dataToVerify = binaryData || (stripTrailingSpaces ? removeTrailingSpaces(textData) : textData); // throw if streamed text and stripTrailingSpaces enabled
     const sanitizedOptions = {
         ...options,
         date,
-        message: await createMessage({ [dataType]: dataToVerify, date })
+        message: await createMessage({ [dataType]: dataToVerify, date }),
+        config: context ? getConfigForContextVerification(config) : config
     };
 
-    return verify(sanitizedOptions).then(handleVerificationResult);
+    const verificationResult = await verify(sanitizedOptions);
+    return handleVerificationResult(verificationResult, context);
 }
 
 /**
@@ -111,11 +128,8 @@ export async function verifyCleartextMessage({ cleartextMessage, date = serverTi
     if (!(cleartextMessage instanceof CleartextMessage)) {
         throw new Error('CleartextMessage expected.');
     }
-    const sanitizedOptions = {
-        ...options,
-        date,
-        message: cleartextMessage
-    };
+    const sanitizedOptions = { ...options, date, message: cleartextMessage };
 
-    return verify(sanitizedOptions).then(handleVerificationResult);
+    const verificationResult = await verify(sanitizedOptions);
+    return handleVerificationResult(verificationResult);
 }

--- a/lib/pmcrypto.d.ts
+++ b/lib/pmcrypto.d.ts
@@ -27,10 +27,12 @@ import {
 } from 'openpgp/lightweight';
 
 import { VERIFICATION_STATUS, SIGNATURE_TYPES } from './constants';
+import type { ContextSigningOptions, ContextVerificationOptions } from './message/context';
 
 export function init(): void;
 
 export { VERIFICATION_STATUS, SIGNATURE_TYPES, PartialConfig };
+export { ContextError } from './message/context';
 
 export type OpenPGPKey = Key;
 export type OpenPGPMessage = Message<Uint8Array | string>; // TODO missing streaming support
@@ -92,6 +94,7 @@ export function decryptSessionKey(options: DecryptSessionKeyOptionsPmcrypto): Pr
 export interface DecryptOptionsPmcrypto<T extends MaybeStream<Data>> extends DecryptOptions {
     message: Message<T>;
     encryptedSignature?: Message<MaybeStream<Data>>;
+    context?: ContextVerificationOptions
 }
 
 export interface DecryptResultPmcrypto<DataType extends openpgp_DecryptMessageResult['data'] = MaybeStream<Data>> {
@@ -139,11 +142,12 @@ export type MaybeStream<T extends Uint8Array | string> = T | WebStream<T>;
 export type Data = string | Uint8Array;
 export { WebStream };
 
-export interface EncryptOptionsPmcrypto<T extends MaybeStream<Data>> extends Omit<EncryptOptions, 'message'> {
+export interface EncryptOptionsPmcrypto<T extends MaybeStream<Data>> extends Omit<EncryptOptions, 'message' | 'signatureNotations'> {
     textData?: T extends MaybeStream<string> ? T : never;
     binaryData?: T extends MaybeStream<Uint8Array> ? T : never;
     stripTrailingSpaces?: T extends MaybeStream<string> ? boolean : never;
     detached?: boolean;
+    context?: ContextSigningOptions;
 }
 
 // No reuse from OpenPGP's equivalent
@@ -193,10 +197,11 @@ export function getMatchingKey(
     publicKeys: OpenPGPKey[]
 ): OpenPGPKey | undefined;
 
-export interface SignOptionsPmcrypto<T extends MaybeStream<Data>> extends Omit<SignOptions, 'message'> {
+export interface SignOptionsPmcrypto<T extends MaybeStream<Data>> extends Omit<SignOptions, 'message' | 'signatureNotations'> {
     textData?: T extends MaybeStream<string> ? T : never;
     binaryData?: T extends MaybeStream<Uint8Array> ? T : never;
     stripTrailingSpaces?: T extends MaybeStream<string> ? boolean : never;
+    context?: ContextSigningOptions;
 }
 
 export function signMessage<
@@ -230,6 +235,7 @@ export { SHA256, SHA512, unsafeMD5, unsafeSHA1 } from './crypto/hash';
 
 export { verifyMessage, verifyCleartextMessage } from './message/verify';
 export type { VerifyCleartextOptionsPmcrypto, VerifyMessageResult, VerifyOptionsPmcrypto } from './message/verify';
+export type { ContextSigningOptions, ContextVerificationOptions };
 
 export { MIMEAttachment, ProcessMIMEOptions, default as processMIME, ProcessMIMEResult } from './message/processMIME';
 

--- a/lib/pmcrypto.js
+++ b/lib/pmcrypto.js
@@ -60,3 +60,5 @@ export { getSHA256Fingerprints } from './key/info';
 export { checkKeyStrength } from './key/check';
 
 export * from './constants';
+
+export { ContextError } from './message/context';

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
                 "@openpgp/tweetnacl": "^1.0.3",
                 "@openpgp/web-stream-tools": "^0.0.13",
                 "jsmimeparser": "npm:@protontech/jsmimeparser@^2.0.1",
-                "openpgp": "npm:@protontech/openpgp@~5.5.0"
+                "openpgp": "npm:@protontech/openpgp@~5.7.0"
             },
             "devDependencies": {
                 "@types/chai": "^4.3.0",
@@ -4361,9 +4361,9 @@
         },
         "node_modules/openpgp": {
             "name": "@protontech/openpgp",
-            "version": "5.5.0",
-            "resolved": "https://registry.npmjs.org/@protontech/openpgp/-/openpgp-5.5.0.tgz",
-            "integrity": "sha512-QABbXrK1AtvIOFy2hPQAvKjr7e6X8On16z2zHwSa6596wwLxrWImW4L8KYJ4kYAcilk3PX9K8EhhrsFzuRm+Ig==",
+            "version": "5.7.0",
+            "resolved": "https://registry.npmjs.org/@protontech/openpgp/-/openpgp-5.7.0.tgz",
+            "integrity": "sha512-ZcdDdHDSHnCZdw9ovM9xnENVTcnG19E3s+WRJ+noMzr7wFUuwjDP2axNV0kCVyDB0VO7GJnVdt/jYkDfRJyPWw==",
             "dependencies": {
                 "asn1.js": "^5.0.0"
             },
@@ -9084,9 +9084,9 @@
             }
         },
         "openpgp": {
-            "version": "npm:@protontech/openpgp@5.5.0",
-            "resolved": "https://registry.npmjs.org/@protontech/openpgp/-/openpgp-5.5.0.tgz",
-            "integrity": "sha512-QABbXrK1AtvIOFy2hPQAvKjr7e6X8On16z2zHwSa6596wwLxrWImW4L8KYJ4kYAcilk3PX9K8EhhrsFzuRm+Ig==",
+            "version": "npm:@protontech/openpgp@5.7.0",
+            "resolved": "https://registry.npmjs.org/@protontech/openpgp/-/openpgp-5.7.0.tgz",
+            "integrity": "sha512-ZcdDdHDSHnCZdw9ovM9xnENVTcnG19E3s+WRJ+noMzr7wFUuwjDP2axNV0kCVyDB0VO7GJnVdt/jYkDfRJyPWw==",
             "requires": {
                 "asn1.js": "^5.0.0"
             }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
         "@openpgp/tweetnacl": "^1.0.3",
         "@openpgp/web-stream-tools": "^0.0.13",
         "jsmimeparser": "npm:@protontech/jsmimeparser@^2.0.1",
-        "openpgp": "npm:@protontech/openpgp@~5.5.0"
+        "openpgp": "npm:@protontech/openpgp@~5.7.0"
     },
     "devDependencies": {
         "@types/chai": "^4.3.0",

--- a/test/message/context.spec.ts
+++ b/test/message/context.spec.ts
@@ -1,0 +1,317 @@
+import { expect } from 'chai';
+import { verifyMessage, signMessage, generateKey, readSignature, readMessage, decryptMessage, encryptMessage, readKey, ContextError } from '../../lib';
+import { VERIFICATION_STATUS } from '../../lib/constants';
+
+// verification without passing context should fail
+// verification passing wrong context should fail
+// verification of unsigned notation data should fail
+describe('context', () => {
+    it('signMessage/verifyMessage - it verifies a message with context (critical)', async () => {
+        const { privateKey, publicKey } = await generateKey({
+            userIDs: [{ name: 'name', email: 'email@test.com' }],
+            format: 'object'
+        });
+        const textData = 'message with context';
+
+        const armoredSignature = await signMessage({
+            textData,
+            signingKeys: [privateKey],
+            context: { value: 'test-context', critical: true },
+            detached: true
+        });
+
+        const verificationValidContext = await verifyMessage({
+            textData,
+            signature: await readSignature({ armoredSignature }),
+            verificationKeys: [publicKey],
+            context: { value: 'test-context', required: true }
+        });
+
+        const verificationWrongContext = await verifyMessage({
+            textData,
+            signature: await readSignature({ armoredSignature }),
+            verificationKeys: [publicKey],
+            context: { value: 'unexpected-context', required: true }
+        });
+
+        const verificationMissingContext = await verifyMessage({
+            textData,
+            signature: await readSignature({ armoredSignature }),
+            verificationKeys: [publicKey]
+        });
+
+        expect(verificationValidContext.verified).to.equal(VERIFICATION_STATUS.SIGNED_AND_VALID);
+        expect(verificationWrongContext.verified).to.equal(VERIFICATION_STATUS.SIGNED_AND_INVALID);
+        expect(verificationMissingContext.verified).to.equal(VERIFICATION_STATUS.SIGNED_AND_INVALID);
+        // check errors
+        expect(verificationValidContext.errors).to.be.undefined;
+        expect(verificationWrongContext.errors).to.have.length(1);
+        expect(verificationWrongContext.errors![0]).to.be.instanceOf(ContextError);
+        expect(verificationMissingContext.errors).to.have.length(1);
+        expect(verificationMissingContext.errors![0]).to.match(/Unknown critical notation: context@proton/);
+    });
+
+    it('signMessage/verifyMessage - it verifies a message with context (non critical)', async () => {
+        const { privateKey, publicKey } = await generateKey({
+            userIDs: [{ name: 'name', email: 'email@test.com' }],
+            format: 'object'
+        });
+        const textData = 'message with context';
+
+        const armoredSignature = await signMessage({
+            textData,
+            signingKeys: [privateKey],
+            context: { value: 'test-context', critical: false },
+            detached: true
+        });
+
+        const verificationValidContext = await verifyMessage({
+            textData,
+            signature: await readSignature({ armoredSignature }),
+            verificationKeys: [publicKey],
+            context: { value: 'test-context', required: true }
+        });
+
+        const verificationWrongContext = await verifyMessage({
+            textData,
+            signature: await readSignature({ armoredSignature }),
+            verificationKeys: [publicKey],
+            context: { value: 'unexpected-context', required: true }
+        });
+
+        const verificationWrongContextNotRequired = await verifyMessage({
+            textData,
+            signature: await readSignature({ armoredSignature }),
+            verificationKeys: [publicKey],
+            context: { value: 'unexpected-context', required: false } // should still fail to verify
+        });
+
+        const verificationMissingContext = await verifyMessage({
+            textData,
+            signature: await readSignature({ armoredSignature }),
+            verificationKeys: [publicKey]
+        });
+
+        expect(verificationValidContext.verified).to.equal(VERIFICATION_STATUS.SIGNED_AND_VALID);
+        expect(verificationWrongContext.verified).to.equal(VERIFICATION_STATUS.SIGNED_AND_INVALID);
+        expect(verificationWrongContextNotRequired.verified).to.equal(VERIFICATION_STATUS.SIGNED_AND_INVALID);
+        expect(verificationMissingContext.verified).to.equal(VERIFICATION_STATUS.SIGNED_AND_VALID);
+        // check errors
+        expect(verificationValidContext.errors).to.be.undefined;
+        expect(verificationWrongContext.errors).to.have.length(1);
+        expect(verificationWrongContext.errors![0]).to.be.instanceOf(ContextError);
+        expect(verificationWrongContextNotRequired.errors).to.have.length(1);
+        expect(verificationWrongContextNotRequired.errors![0]).to.be.instanceOf(ContextError);
+        expect(verificationMissingContext.errors).to.be.undefined;
+    });
+
+    it('encryptMessage/decryptMessage - it verifies a message with context', async () => {
+        const { privateKey, publicKey } = await generateKey({
+            userIDs: [{ name: 'name', email: 'email@test.com' }],
+            format: 'object'
+        });
+
+        const { message: armoredMessage } = await encryptMessage({
+            textData: 'message with context',
+            encryptionKeys: publicKey,
+            signingKeys: privateKey,
+            context: { value: 'test-context', critical: true }
+        });
+
+        const decryptionValidContext = await decryptMessage({
+            message: await readMessage({ armoredMessage }),
+            decryptionKeys: privateKey,
+            verificationKeys: publicKey,
+            context: { value: 'test-context', required: true }
+        });
+
+        const decryptionWrongContext = await decryptMessage({
+            message: await readMessage({ armoredMessage }),
+            decryptionKeys: privateKey,
+            verificationKeys: publicKey,
+            context: { value: 'unexpected-context', required: true }
+        });
+
+        const decryptionMissingContext = await await decryptMessage({
+            message: await readMessage({ armoredMessage }),
+            decryptionKeys: privateKey,
+            verificationKeys: publicKey
+        });
+
+        expect(decryptionValidContext.verified).to.equal(VERIFICATION_STATUS.SIGNED_AND_VALID);
+        expect(decryptionWrongContext.verified).to.equal(VERIFICATION_STATUS.SIGNED_AND_INVALID);
+        expect(decryptionMissingContext.verified).to.equal(VERIFICATION_STATUS.SIGNED_AND_INVALID);
+        // check errors
+        expect(decryptionValidContext.verificationErrors).to.be.undefined;
+        expect(decryptionWrongContext.verificationErrors).to.have.length(1);
+        expect(decryptionWrongContext.verificationErrors![0]).to.be.instanceOf(ContextError);
+        expect(decryptionMissingContext.verificationErrors).to.have.length(1);
+        expect(decryptionMissingContext.verificationErrors![0]).to.match(/Unknown critical notation: context@proton/);
+    });
+
+    it('encryptMessage/decryptMessage - it verifies an encrypted signature with context', async () => {
+        const { privateKey, publicKey } = await generateKey({
+            userIDs: [{ name: 'name', email: 'email@test.com' }],
+            format: 'object'
+        });
+
+        const { message: armoredMessage, encryptedSignature } = await encryptMessage({
+            textData: 'message with context',
+            encryptionKeys: publicKey,
+            signingKeys: privateKey,
+            context: { value: 'test-context', critical: true },
+            detached: true
+        });
+
+        const decryptionValidContext = await decryptMessage({
+            message: await readMessage({ armoredMessage }),
+            encryptedSignature: await readMessage({ armoredMessage: encryptedSignature }),
+            decryptionKeys: privateKey,
+            verificationKeys: publicKey,
+            context: { value: 'test-context', required: true }
+        });
+
+        const decryptionWrongContext = await decryptMessage({
+            message: await readMessage({ armoredMessage }),
+            encryptedSignature: await readMessage({ armoredMessage: encryptedSignature }),
+            decryptionKeys: privateKey,
+            verificationKeys: publicKey,
+            context: { value: 'unexpected-context', required: true }
+        });
+
+        const decryptionMissingContext = await await decryptMessage({
+            message: await readMessage({ armoredMessage }),
+            encryptedSignature: await readMessage({ armoredMessage: encryptedSignature }),
+            decryptionKeys: privateKey,
+            verificationKeys: publicKey
+        });
+
+        expect(decryptionValidContext.verified).to.equal(VERIFICATION_STATUS.SIGNED_AND_VALID);
+        expect(decryptionWrongContext.verified).to.equal(VERIFICATION_STATUS.SIGNED_AND_INVALID);
+        expect(decryptionMissingContext.verified).to.equal(VERIFICATION_STATUS.SIGNED_AND_INVALID);
+        // check errors
+        expect(decryptionValidContext.verificationErrors).to.be.undefined;
+        expect(decryptionWrongContext.verificationErrors).to.have.length(1);
+        expect(decryptionWrongContext.verificationErrors![0]).to.be.instanceOf(ContextError);
+        expect(decryptionMissingContext.verificationErrors).to.have.length(1);
+        expect(decryptionMissingContext.verificationErrors![0]).to.match(/Unknown critical notation: context@proton/);
+    });
+
+    it('does not verify a message without context', async () => {
+        const { privateKey, publicKey } = await generateKey({
+            userIDs: [{ name: 'name', email: 'email@test.com' }],
+            format: 'object'
+        });
+        const textData = 'message without context';
+
+        const armoredSignature = await signMessage({
+            textData,
+            signingKeys: [privateKey],
+            detached: true
+        });
+
+        const verificationExpectedContext = await verifyMessage({
+            textData,
+            signature: await readSignature({ armoredSignature }),
+            verificationKeys: [publicKey],
+            context: { value: 'test-context', required: true }
+        });
+
+        const verificationNoExpectedContext = await verifyMessage({
+            textData,
+            signature: await readSignature({ armoredSignature }),
+            verificationKeys: [publicKey],
+            context: { value: 'test-context', required: false }
+        });
+
+        expect(verificationExpectedContext.verified).to.equal(VERIFICATION_STATUS.SIGNED_AND_INVALID);
+        expect(verificationNoExpectedContext.verified).to.equal(VERIFICATION_STATUS.SIGNED_AND_VALID);
+
+        expect(verificationNoExpectedContext.errors).to.be.undefined;
+        expect(verificationExpectedContext.errors).to.have.length(1);
+        expect(verificationExpectedContext.errors![0]).to.be.instanceOf(ContextError);
+    });
+
+    it('does not verify a message without context based on cutoff date (`expectFrom`)', async () => {
+        const now = new Date();
+        const nextHour = new Date(+now + (3600 * 1000));
+        const { privateKey, publicKey } = await generateKey({
+            userIDs: [{ name: 'name', email: 'email@test.com' }],
+            format: 'object',
+            date: now
+        });
+        const textData = 'message without context';
+
+        const armoredSignature = await signMessage({
+            textData,
+            signingKeys: [privateKey],
+            detached: true,
+            date: now
+        });
+
+        const verificationExpectedContext = await verifyMessage({
+            textData,
+            signature: await readSignature({ armoredSignature }),
+            verificationKeys: [publicKey],
+            context: { value: 'test-context', requiredAfter: now }
+        });
+
+        const verificationNoExpectedContext = await verifyMessage({
+            textData,
+            signature: await readSignature({ armoredSignature }),
+            verificationKeys: [publicKey],
+            context: { value: 'test-context', requiredAfter: nextHour }
+        });
+
+        expect(verificationExpectedContext.verified).to.equal(VERIFICATION_STATUS.SIGNED_AND_INVALID);
+        expect(verificationNoExpectedContext.verified).to.equal(VERIFICATION_STATUS.SIGNED_AND_VALID);
+
+        expect(verificationNoExpectedContext.errors).to.be.undefined;
+        expect(verificationExpectedContext.errors).to.have.length(1);
+        expect(verificationExpectedContext.errors![0]).to.be.instanceOf(ContextError);
+    });
+
+    it('does not verify signature with unsigned notation data', async () => {
+        // this signature contains context (i.e. notation data) but it is under the unhashed subpackets,
+        // hence it is not signed. If context is requested on verification, the signature must fail to verify.
+        const armoredSignature = `-----BEGIN PGP SIGNATURE-----
+
+wqUEARYKACcFgmPzZJwJkF8qvvnS11F+FiEECOeCETwii9eyPf0HXyq++dLX
+UX4AMC+UgAAAAAARABVjb250ZXh0QHByb3Rvbi5jaHRlc3QtY29udGV4dC11
+bnNpZ25lZPQKAQDKi7isJlPfxwgpYg9KagZ1sxuWd3FRyfUyMJOwOkZdwwEA
+6ldLiUgk/6BrpsGNTLWAT4O7YuM3IYOuZ8vZJejewQU=
+=gtRt
+-----END PGP SIGNATURE-----`;
+        const publicKey = await readKey({ armoredKey: `-----BEGIN PGP PUBLIC KEY BLOCK-----
+
+xjMEY/NkkRYJKwYBBAHaRw8BAQdA3sPX38x7/uqy9u4NyPCwrqToJk/jQuyP
+xlXfcQSsxFrNFnRlc3QgPHRlc3RAY29udGV4dC5jaD7CjAQQFgoAPgWCY/Nk
+kQQLCQcICZBfKr750tdRfgMVCAoEFgACAQIZAQKbAwIeARYhBAjnghE8IovX
+sj39B18qvvnS11F+AACnNAEAqw9Y3I8kRKBmWUoSYaYVqt0sm3WAFCIy4cFj
+vMeC6QYBAIszizj9K6Gupu700k5VfkbX4zugd+zohD5/yo5k4kEEzjgEY/Nk
+kRIKKwYBBAGXVQEFAQEHQO8irSRCCChqiAc29oERDIYPjQRhVYNq8ZmqVain
+rdNNAwEIB8J4BBgWCAAqBYJj82SRCZBfKr750tdRfgKbDBYhBAjnghE8IovX
+sj39B18qvvnS11F+AAB7igEAqwmlDXMzeNNLc3skdyQWZoP0fPyI/ol7pMa+
+7KJS6W4BAKDInHhNEuH3N5DnqwARs8kPDDSNaRNGipxcuYTbFLAO
+=PFUt
+-----END PGP PUBLIC KEY BLOCK-----` });
+        const textData = 'message with unsigned context';
+
+        const verificationWithContext = await verifyMessage({
+            textData,
+            signature: await readSignature({ armoredSignature }),
+            verificationKeys: [publicKey],
+            context: { value: 'test-context-unsigned', required: true }
+        });
+
+        // no context expected, so unsigned notation data should be simply ignored
+        const verificationWithoutContext = await verifyMessage({
+            textData,
+            signature: await readSignature({ armoredSignature }),
+            verificationKeys: publicKey
+        });
+
+        expect(verificationWithContext.verified).to.equal(VERIFICATION_STATUS.SIGNED_AND_INVALID);
+        expect(verificationWithoutContext.verified).to.equal(VERIFICATION_STATUS.SIGNED_AND_VALID);
+    });
+});

--- a/test/message/encryptMessage.spec.ts
+++ b/test/message/encryptMessage.spec.ts
@@ -178,9 +178,13 @@ describe('message encryption and decryption', () => {
             signingKeys: [decryptedPrivateKey],
             detached: true
         });
+
+        const parsedEncryptedSignature = await readMessage({ armoredMessage: encryptedSignature });
+        expect(parsedEncryptedSignature.getSigningKeyIDs()).to.have.length(0); // the encrypted message containing the signature should not be signed
+
         const { data: decrypted, verified } = await decryptMessage({
             message: await readMessage({ armoredMessage: encrypted }),
-            encryptedSignature: await readMessage({ armoredMessage: encryptedSignature }),
+            encryptedSignature: parsedEncryptedSignature,
             verificationKeys: [decryptedPrivateKey.toPublic()],
             decryptionKeys: [decryptedPrivateKey]
         });


### PR DESCRIPTION
The context is an abstraction we use to add domain separation to OpenPGP signatures.
 It's implemented by adding notation data to signatures, marked as critical, so that the resulting signature can only be verified by a verifier who expects the context to be present.
 
TODO:

- [x]  point to released openpgpjs 