### PR TITLE
`decryptLegacy`: dynamically import AES_CFB only when processing a legacy message

### DIFF
--- a/lib/crypto/cfb.js
+++ b/lib/crypto/cfb.js
@@ -1,3 +1,4 @@
+// This is only used in `decryptLegacy`
 import { AES_CFB } from '@openpgp/asmcrypto.js/dist_es8/aes/cfb';
 
 export const AES256 = {

--- a/lib/message/decryptLegacy.js
+++ b/lib/message/decryptLegacy.js
@@ -1,4 +1,3 @@
-import { AES256 as AES_CFB } from '../crypto/cfb';
 import { VERIFICATION_STATUS } from '../constants';
 import { arrayToBinaryString, binaryStringToArray, decodeUtf8Base64 } from '../utils';
 import decryptMessage from './decrypt';
@@ -77,6 +76,7 @@ export default async function decryptMessageLegacy({ messageDate, armoredMessage
     oldEncMessage = binaryStringToArray(decodeUtf8Base64(oldEncMessage));
 
     const params = { verified: VERIFICATION_STATUS.NOT_SIGNED, signatures: [], verificationErrors };
+    const { AES256: AES_CFB } = await import('../crypto/cfb');
 
     // OpenPGP CFB mode with resync (https://tools.ietf.org/html/rfc4880#section-13.9)
     const result = await AES_CFB.decrypt(


### PR DESCRIPTION
This allows bundling the AES code separately (~10KB). The asmcrypto import is to be removed in favour of SubtleCrypto API.