### PR TITLE
Add build step before publishing the package

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,3 +30,6 @@ jobs:
 
       - name: Run tests
         run: npm test
+
+      - name: Check build
+        run: npm run build

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 .DS_Store
 /build
 .vscode
+dist

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
         "stream": false
     },
     "files": [
+        "dist/",
         "lib/",
         "tsconfig.json"
     ],
@@ -16,7 +17,9 @@
         "test": "karma start karma.conf.js",
         "lint": "eslint lib test --quiet",
         "postversion": "git push && git push --tags",
-        "test-type-definitions": "tsc"
+        "test-type-definitions": "tsc",
+        "build": "tsc -p tsconfig.build.json",
+        "prepack": "npm run build"
     },
     "repository": {
         "type": "git",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "module": "CommonJS",
+        "outDir": "dist",
+        "declaration": true,
+        "noEmit": false
+    },
+    "include": ["lib/**/*"]
+}


### PR DESCRIPTION
Add `prepack` npm script that automatically runs before `npm publish`. The script runs basic compilation TypeScript -> CommonJS and outputs the result to `dist` folder.
This way, it will be possible to import pmcrypto library as CommonJS dependency. It's critical in some contexts, like for example Playwright.