### PR TITLE
`processMIME`: fix decoding of UTF8 body parts with 8bit transfer-encoding

### DIFF
--- a/lib/message/parseMail.ts
+++ b/lib/message/parseMail.ts
@@ -5,7 +5,7 @@ export type { Attachment } from 'jsmimeparser';
  * Parse a mail into an object format, splitting, headers, html, text/plain and attachments.
  * As jsmime is not a small library, we only want to import it if it's actually used.
  */
-export const parseMail = (mail: string) => import('jsmimeparser').then(({ parseMail: jsmimeParseEmail }) => jsmimeParseEmail(mail));
+export const parseMail = (mail: string | Uint8Array) => import('jsmimeparser').then(({ parseMail: jsmimeParseEmail }) => jsmimeParseEmail(mail));
 
 // Mapping between mime types to the corresponding extensions.
 // This is only used if the parsed attachment does not include a filename.

--- a/lib/message/processMIME.ts
+++ b/lib/message/processMIME.ts
@@ -122,7 +122,7 @@ const parse = async (
         // the headers for this current message shouldn't be carried over to the next message.
         attachment.fileName = `${headerFilename}.txt`;
         attachment.contentDisposition = 'attachment';
-        const { from, subject: attachmentSubject } = await parseMail(utf8ArrayToString(parsedAttachment.content));
+        const { from, subject: attachmentSubject } = await parseMail(parsedAttachment.content);
         // check for subject headers and from headers to match the current message with the right sender.
         if (!attachmentSubject || !from) {
             continue;

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
                 "@openpgp/noble-hashes": "^1.3.2-1",
                 "@openpgp/tweetnacl": "^1.0.3",
                 "@openpgp/web-stream-tools": "^0.0.13",
-                "jsmimeparser": "npm:@protontech/jsmimeparser@^2.0.1",
+                "jsmimeparser": "npm:@protontech/jsmimeparser@^2.1.0",
                 "openpgp": "npm:@protontech/openpgp@~5.9.0"
             },
             "devDependencies": {
@@ -3597,9 +3597,9 @@
         },
         "node_modules/jsmimeparser": {
             "name": "@protontech/jsmimeparser",
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/@protontech/jsmimeparser/-/jsmimeparser-2.0.1.tgz",
-            "integrity": "sha512-FBT3sT1pm+fDjHBbnbmjsLo4SN77FHQOUT9ZylDbzYILBBpAQh3o4ghPWtkl72zEtlDyOgVUq5DboxNakbklGA=="
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@protontech/jsmimeparser/-/jsmimeparser-2.1.0.tgz",
+            "integrity": "sha512-QezgETMEnQXK/J5OWjASHyau4jG2+Pqv8wZGwUJLVZLeCCt8FdEkRjp7UeFRQjlkWJHqIufzST6KW+ddjtrdbw=="
         },
         "node_modules/json-parse-even-better-errors": {
             "version": "2.3.1",
@@ -8649,9 +8649,9 @@
             }
         },
         "jsmimeparser": {
-            "version": "npm:@protontech/jsmimeparser@2.0.1",
-            "resolved": "https://registry.npmjs.org/@protontech/jsmimeparser/-/jsmimeparser-2.0.1.tgz",
-            "integrity": "sha512-FBT3sT1pm+fDjHBbnbmjsLo4SN77FHQOUT9ZylDbzYILBBpAQh3o4ghPWtkl72zEtlDyOgVUq5DboxNakbklGA=="
+            "version": "npm:@protontech/jsmimeparser@2.1.0",
+            "resolved": "https://registry.npmjs.org/@protontech/jsmimeparser/-/jsmimeparser-2.1.0.tgz",
+            "integrity": "sha512-QezgETMEnQXK/J5OWjASHyau4jG2+Pqv8wZGwUJLVZLeCCt8FdEkRjp7UeFRQjlkWJHqIufzST6KW+ddjtrdbw=="
         },
         "json-parse-even-better-errors": {
             "version": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
         "@openpgp/noble-hashes": "^1.3.2-1",
         "@openpgp/tweetnacl": "^1.0.3",
         "@openpgp/web-stream-tools": "^0.0.13",
-        "jsmimeparser": "npm:@protontech/jsmimeparser@^2.0.1",
+        "jsmimeparser": "npm:@protontech/jsmimeparser@^2.1.0",
         "openpgp": "npm:@protontech/openpgp@~5.9.0"
     },
     "devDependencies": {

--- a/test/message/processMIME.spec.ts
+++ b/test/message/processMIME.spec.ts
@@ -18,6 +18,27 @@ import {
 } from './processMIME.data';
 
 describe('processMIME', () => {
+    it('it correctly decodes UTF-8 body with 8bit transfer encoding', async () => {
+        const { body } = await processMIME({
+            data: `From: Some One <someone@example.com>
+To: "Someone Else" <someone-else@example.com>
+MIME-Version: 1.0
+Content-Type: multipart/mixed;
+    boundary="------------cJMvmFk1NneB7MT4jwYHY7ap"
+
+This is a multi-part message in MIME format.
+--------------cJMvmFk1NneB7MT4jwYHY7ap
+Content-Type: text/plain; charset=UTF-8;
+Content-Transfer-Encoding: 8bit
+
+Import HTML cöntäct//Subjεέςτ//
+
+--------------cJMvmFk1NneB7MT4jwYHY7ap--`,
+            verificationKeys: []
+        });
+        expect(body).to.equal('Import HTML cöntäct//Subjεέςτ//\n');
+    });
+
     it('it can process multipart/signed mime messages and verify the signature', async () => {
         const { body, verified, signatures, attachments, encryptedSubject } = await processMIME(
             {


### PR DESCRIPTION
UTF-8 body parts with non-ASCII chars transferred in 8bit format (as opposed to quoted-printable or base64) could be decoded incorrectly by jsmimeparser.

Decoding of non-UTF8 data in 8bit remains unsupported, since we are not aware of any users being affected.