### PR TITLE
`processMIME`: do not throw on missing or malformed signature

### DIFF
--- a/lib/message/processMIME.ts
+++ b/lib/message/processMIME.ts
@@ -51,7 +51,15 @@ const verifySignature = async (
     }
     const sigData = utf8ArrayToString(sigAttachmentContent);
 
-    const signature = await readSignature({ armoredSignature: sigData });
+    let signature;
+    try {
+        signature = await readSignature({ armoredSignature: sigData });
+    } catch {
+        // sigData will be returned as attachment by `parse`
+        console.error('Failed to read signature over MIME message');
+        return { subdata: data, verified: 0, signatures: [] };
+    }
+
     const body = parts[1];
 
     const {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
                 "@openpgp/noble-hashes": "^1.3.2-1",
                 "@openpgp/tweetnacl": "^1.0.3",
                 "@openpgp/web-stream-tools": "^0.0.13",
-                "jsmimeparser": "npm:@protontech/jsmimeparser@^3.0.0",
+                "jsmimeparser": "npm:@protontech/jsmimeparser@^3.0.1",
                 "openpgp": "npm:@protontech/openpgp@~5.9.0"
             },
             "devDependencies": {
@@ -3606,9 +3606,9 @@
         },
         "node_modules/jsmimeparser": {
             "name": "@protontech/jsmimeparser",
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@protontech/jsmimeparser/-/jsmimeparser-3.0.0.tgz",
-            "integrity": "sha512-pLX47bDOXTI9b/qliGlRBIRYFKc3qRulPeHpNWNbleqxeedTtd0TRtjRWnDnxq3OuAjW/atY9+UgU+iCLVXPHA=="
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/@protontech/jsmimeparser/-/jsmimeparser-3.0.1.tgz",
+            "integrity": "sha512-bi0RBkritKep1cKnQ6U1538++aQ+7XZxG5Uzm4ZivvP7FTE3iaOA5lm0CCFbSoQ5e8KtvjI5KR+Vj6apXhyhXQ=="
         },
         "node_modules/json-parse-even-better-errors": {
             "version": "2.3.1",
@@ -8655,9 +8655,9 @@
             }
         },
         "jsmimeparser": {
-            "version": "npm:@protontech/jsmimeparser@3.0.0",
-            "resolved": "https://registry.npmjs.org/@protontech/jsmimeparser/-/jsmimeparser-3.0.0.tgz",
-            "integrity": "sha512-pLX47bDOXTI9b/qliGlRBIRYFKc3qRulPeHpNWNbleqxeedTtd0TRtjRWnDnxq3OuAjW/atY9+UgU+iCLVXPHA=="
+            "version": "npm:@protontech/jsmimeparser@3.0.1",
+            "resolved": "https://registry.npmjs.org/@protontech/jsmimeparser/-/jsmimeparser-3.0.1.tgz",
+            "integrity": "sha512-bi0RBkritKep1cKnQ6U1538++aQ+7XZxG5Uzm4ZivvP7FTE3iaOA5lm0CCFbSoQ5e8KtvjI5KR+Vj6apXhyhXQ=="
         },
         "json-parse-even-better-errors": {
             "version": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
         "@openpgp/noble-hashes": "^1.3.2-1",
         "@openpgp/tweetnacl": "^1.0.3",
         "@openpgp/web-stream-tools": "^0.0.13",
-        "jsmimeparser": "npm:@protontech/jsmimeparser@^3.0.0",
+        "jsmimeparser": "npm:@protontech/jsmimeparser@^3.0.1",
         "openpgp": "npm:@protontech/openpgp@~5.9.0"
     },
     "devDependencies": {

--- a/test/message/processMIME.data.ts
+++ b/test/message/processMIME.data.ts
@@ -288,3 +288,35 @@ Content-Transfer-Encoding: 7bit
 
 
 --------------P7E1gxp6rCvfn0to5n3PZ2h0--`;
+
+export const messageWithEmptySignature = `Content-Type: multipart/signed; protocol="application/pgp-signature";\n micalg="pgp-sha256"; boundary="===============9034558267015095129=="
+MIME-Version: 1.0
+
+--===============9034558267015095129==
+MIME-Version: 1.0
+Content-Type: multipart/alternative; boundary="--==_mimepart_64c6b73c4dd6d_2292b028ca3c6b8191503f"; charset=UTF-8
+Content-Transfer-Encoding: 7bit
+
+This is a multi-part message in MIME format.
+----==_mimepart_64c6b73c4dd6d_2292b028ca3c6b8191503f
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: quoted-printable
+
+Hello
+
+----==_mimepart_64c6b73c4dd6d_2292b028ca3c6b8191503f
+Content-Type: text/html; charset=UTF-8
+Content-Transfer-Encoding: quoted-printable
+
+<div>Hello</div>
+
+----==_mimepart_64c6b73c4dd6d_2292b028ca3c6b8191503f--
+
+--===============9034558267015095129==
+Content-Type: application/pgp-signature; name="signature.asc"
+MIME-Version: 1.0
+Content-Disposition: attachment; filename="signature.asc"
+
+
+--===============9034558267015095129==--
+`;

--- a/test/message/processMIME.spec.ts
+++ b/test/message/processMIME.spec.ts
@@ -15,7 +15,8 @@ import {
     key,
     multipartMessageWithUnnamedAttachments,
     multipartMessageWithEncryptedSubjectUTF8,
-    messageWithEmptyBody
+    messageWithEmptyBody,
+    messageWithEmptySignature
 } from './processMIME.data';
 
 describe('processMIME', () => {
@@ -56,7 +57,7 @@ Import HTML cöntäct//Subjεέςτ//
     });
 
     it('it can process multipart/signed mime messages and verify the signature with extra parts at the end', async () => {
-        const { body, verified, signatures } = await processMIME(
+        const { body, verified, signatures, attachments } = await processMIME(
             {
                 data: extraMultipartSignedMessage,
                 verificationKeys: await readKey({ armoredKey: key })
@@ -65,6 +66,7 @@ Import HTML cöntäct//Subjεέςτ//
         expect(verified).to.equal(VERIFICATION_STATUS.SIGNED_AND_VALID);
         expect(body).to.equal('hello');
         expect(signatures.length).to.equal(1);
+        expect(attachments.length).to.equal(0);
     });
 
     it('it does not verify invalid messages', async () => {
@@ -96,6 +98,17 @@ Import HTML cöntäct//Subjεέςτ//
             data: messageWithEmptyBody
         });
         expect(body).to.equal('');
+    });
+
+    it('it can parse message with empty signature', async () => {
+        const { body, signatures, verified, attachments } = await processMIME({
+            data: messageWithEmptySignature
+        });
+        expect(verified).to.equal(VERIFICATION_STATUS.NOT_SIGNED);
+        expect(signatures).to.have.length(0);
+        expect(body).to.equal('<div>Hello</div>\n');
+        expect(attachments).to.have.length(1); // signature part that failed to parse
+        expect(attachments[0].content).to.have.length(0);
     });
 
     it('it can parse message with text attachment', async () => {


### PR DESCRIPTION
If the signature fails to parse, we mark the message as 'not signed' and return the malformed signature as an attachment.