### PR TITLE
`generateForwardingMaterial`: set forwarding flag on encryption subkeys

### DIFF
--- a/lib/key/forwarding.ts
+++ b/lib/key/forwarding.ts
@@ -1,4 +1,4 @@
-import { KDFParams, PrivateKey, UserID, SecretSubkeyPacket, MaybeArray, Subkey, config as defaultConfig } from '../openpgp';
+import { KDFParams, PrivateKey, UserID, SecretSubkeyPacket, MaybeArray, Subkey, config as defaultConfig, SubkeyOptions } from '../openpgp';
 import { generateKey, reformatKey } from './utils';
 
 // TODO (investigate): top-level import of BigIntegerInterface causes issues in Jest tests in web-clients;
@@ -89,7 +89,7 @@ export async function generateForwardingMaterial(
     const { privateKey: forwardeeKeyToSetup } = await generateKey({ // TODO handle v6 keys
         type: 'ecc',
         userIDs: userIDsForForwardeeKey,
-        subkeys: new Array(forwarderEncryptionKeys.length).fill({ curve: curveName }),
+        subkeys: new Array<SubkeyOptions>(forwarderEncryptionKeys.length).fill({ curve: curveName, forwarding: true }),
         format: 'object'
     });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
                 "@openpgp/tweetnacl": "^1.0.3",
                 "@openpgp/web-stream-tools": "^0.0.13",
                 "jsmimeparser": "npm:@protontech/jsmimeparser@^3.0.1",
-                "openpgp": "larabr/openpgpjs#forwarding-generate-key-0x40"
+                "openpgp": "npm:@protontech/openpgp@~5.9.1-1"
             },
             "devDependencies": {
                 "@types/bn.js": "^5.1.1",
@@ -4484,9 +4484,9 @@
         },
         "node_modules/openpgp": {
             "name": "@protontech/openpgp",
-            "version": "5.9.1-0",
-            "resolved": "git+ssh://git@github.com/larabr/openpgpjs.git#c11e977b75cfbf40c085c89b3644c216022deac7",
-            "license": "LGPL-3.0+",
+            "version": "5.9.1-1",
+            "resolved": "https://registry.npmjs.org/@protontech/openpgp/-/openpgp-5.9.1-1.tgz",
+            "integrity": "sha512-pY69WrGNTwEDVI7ZiK/KTy2aLZKn8Tj9Iyh/aaa/Imh5KHtYK6pcoeMeLT/ebA2BXOeccf1FrvWy117deRi2TA==",
             "dependencies": {
                 "asn1.js": "^5.0.0"
             },
@@ -9314,8 +9314,9 @@
             }
         },
         "openpgp": {
-            "version": "git+ssh://git@github.com/larabr/openpgpjs.git#c11e977b75cfbf40c085c89b3644c216022deac7",
-            "from": "openpgp@larabr/openpgpjs#forwarding-generate-key-0x40",
+            "version": "npm:@protontech/openpgp@5.9.1-1",
+            "resolved": "https://registry.npmjs.org/@protontech/openpgp/-/openpgp-5.9.1-1.tgz",
+            "integrity": "sha512-pY69WrGNTwEDVI7ZiK/KTy2aLZKn8Tj9Iyh/aaa/Imh5KHtYK6pcoeMeLT/ebA2BXOeccf1FrvWy117deRi2TA==",
             "requires": {
                 "asn1.js": "^5.0.0"
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
                 "@openpgp/tweetnacl": "^1.0.3",
                 "@openpgp/web-stream-tools": "^0.0.13",
                 "jsmimeparser": "npm:@protontech/jsmimeparser@^3.0.1",
-                "openpgp": "npm:@protontech/openpgp@~5.9.1-0"
+                "openpgp": "larabr/openpgpjs#forwarding-generate-key-0x40"
             },
             "devDependencies": {
                 "@types/bn.js": "^5.1.1",
@@ -4485,8 +4485,8 @@
         "node_modules/openpgp": {
             "name": "@protontech/openpgp",
             "version": "5.9.1-0",
-            "resolved": "https://registry.npmjs.org/@protontech/openpgp/-/openpgp-5.9.1-0.tgz",
-            "integrity": "sha512-cXiDUh6rbg0bhP95Y0rJQR+KG5nRrlZaqPdE4/hC5Ewle3S4rrBSZYUWM+JZV7PV8FVc2UdCG/iFumSMfVb1Lg==",
+            "resolved": "git+ssh://git@github.com/larabr/openpgpjs.git#c11e977b75cfbf40c085c89b3644c216022deac7",
+            "license": "LGPL-3.0+",
             "dependencies": {
                 "asn1.js": "^5.0.0"
             },
@@ -9314,9 +9314,8 @@
             }
         },
         "openpgp": {
-            "version": "npm:@protontech/openpgp@5.9.1-0",
-            "resolved": "https://registry.npmjs.org/@protontech/openpgp/-/openpgp-5.9.1-0.tgz",
-            "integrity": "sha512-cXiDUh6rbg0bhP95Y0rJQR+KG5nRrlZaqPdE4/hC5Ewle3S4rrBSZYUWM+JZV7PV8FVc2UdCG/iFumSMfVb1Lg==",
+            "version": "git+ssh://git@github.com/larabr/openpgpjs.git#c11e977b75cfbf40c085c89b3644c216022deac7",
+            "from": "openpgp@larabr/openpgpjs#forwarding-generate-key-0x40",
             "requires": {
                 "asn1.js": "^5.0.0"
             }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
         "@openpgp/tweetnacl": "^1.0.3",
         "@openpgp/web-stream-tools": "^0.0.13",
         "jsmimeparser": "npm:@protontech/jsmimeparser@^3.0.1",
-        "openpgp": "npm:@protontech/openpgp@~5.9.1-0"
+        "openpgp": "larabr/openpgpjs#forwarding-generate-key-0x40"
     },
     "devDependencies": {
         "@types/bn.js": "^5.1.1",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
         "@openpgp/tweetnacl": "^1.0.3",
         "@openpgp/web-stream-tools": "^0.0.13",
         "jsmimeparser": "npm:@protontech/jsmimeparser@^3.0.1",
-        "openpgp": "larabr/openpgpjs#forwarding-generate-key-0x40"
+        "openpgp": "npm:@protontech/openpgp@~5.9.1-1"
     },
     "devDependencies": {
         "@types/bn.js": "^5.1.1",


### PR DESCRIPTION
A specific flag needs to be set for forwarding subkeys instead of the standard EtEr ones. In fact, encrypting to them directly is not allowed.

Also, setting `config.allowForwardedMessages` is now required to decrypt (this was previously not enforced due to a bug in OpenPGP.js)