### PR TITLE
Add Argon2 helper to derive keys outside of the OpenPGP context

### DIFF
--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -16,3 +16,8 @@ export const MAX_ENC_HEADER_LENGTH = 1024;
  * across different servers, which might have slightly mismatching server time
  */
 export const DEFAULT_OFFSET = -60000;
+
+export const ARGON2_PARAMS = { // from https://www.rfc-editor.org/rfc/rfc9106.html#name-parameter-choice
+    RECOMMENDED: { passes: 1, parallelism: 4, memoryExponent: 21, tagLength: 32 },
+    MINIMUM: { passes: 3, parallelism: 4, memoryExponent: 16, tagLength: 32 }
+};

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -18,6 +18,6 @@ export const MAX_ENC_HEADER_LENGTH = 1024;
 export const DEFAULT_OFFSET = -60000;
 
 export const ARGON2_PARAMS = { // from https://www.rfc-editor.org/rfc/rfc9106.html#name-parameter-choice
-    RECOMMENDED: { passes: 1, parallelism: 4, memoryExponent: 21, tagLength: 32 },
+    RECOMMENDED: { passes: 1, parallelism: 4, memoryExponent: 19, tagLength: 32 },
     MINIMUM: { passes: 3, parallelism: 4, memoryExponent: 16, tagLength: 32 }
 };

--- a/lib/crypto/argon2.ts
+++ b/lib/crypto/argon2.ts
@@ -1,0 +1,19 @@
+import { Argon2S2K, Config, config as defaultConfig } from '../openpgp';
+import { ARGON2_PARAMS } from '../constants';
+
+type Argon2Params = Config['s2kArgon2Params'] & {
+    tagLength: number
+};
+
+export interface Argon2Options {
+    password: string,
+    salt: Uint8Array,
+    /** see https://www.rfc-editor.org/rfc/rfc9106.html#name-parameter-choice */
+    params: Argon2Params
+}
+
+export async function argon2({ password, salt, params = ARGON2_PARAMS.RECOMMENDED }: Argon2Options) {
+    const s2k = new Argon2S2K({ ...defaultConfig, s2kArgon2Params: params });
+    s2k.salt = salt;
+    return s2k.produceKey(password, params.tagLength);
+}

--- a/lib/pmcrypto.d.ts
+++ b/lib/pmcrypto.d.ts
@@ -214,6 +214,7 @@ export interface AlgorithmInfo {
 }
 
 export { SHA256, SHA512, unsafeMD5, unsafeSHA1 } from './crypto/hash';
+export { argon2, Argon2Options } from './crypto/argon2';
 
 export { verifyMessage, verifyCleartextMessage } from './message/verify';
 export type { VerifyCleartextOptionsPmcrypto, VerifyMessageResult, VerifyOptionsPmcrypto } from './message/verify';

--- a/lib/pmcrypto.js
+++ b/lib/pmcrypto.js
@@ -20,6 +20,7 @@ export function init() {
 export { updateServerTime, serverTime } from './serverTime';
 
 export { SHA256, SHA512, unsafeMD5, unsafeSHA1 } from './crypto/hash';
+export { argon2 } from './crypto/argon2';
 
 export {
     generateKey,

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
                 "@openpgp/tweetnacl": "^1.0.3",
                 "@openpgp/web-stream-tools": "^0.0.13",
                 "jsmimeparser": "npm:@protontech/jsmimeparser@^3.0.1",
-                "openpgp": "npm:@protontech/openpgp@~5.11.0"
+                "openpgp": "npm:@protontech/openpgp@~5.11.1-0"
             },
             "devDependencies": {
                 "@types/bn.js": "^5.1.1",
@@ -4484,9 +4484,9 @@
         },
         "node_modules/openpgp": {
             "name": "@protontech/openpgp",
-            "version": "5.11.0",
-            "resolved": "https://registry.npmjs.org/@protontech/openpgp/-/openpgp-5.11.0.tgz",
-            "integrity": "sha512-U6I0B66kwGs9hczSbRKGIEDOPfJSmF4Ncf2RBWsRHuF0t5vR0rX8jaBf0tlAqHAGfhr+6PySN0m5nJo2XmF/wA==",
+            "version": "5.11.1-0",
+            "resolved": "https://registry.npmjs.org/@protontech/openpgp/-/openpgp-5.11.1-0.tgz",
+            "integrity": "sha512-FdKcZVpDXCW9ER+zLWuFHkEsaWfukf+wbZeO90CgL20Hvjry0ZWe/xw49QSL6Y6C//6d0GRk066sukrBEhAsMg==",
             "dependencies": {
                 "asn1.js": "^5.0.0"
             },
@@ -9316,9 +9316,9 @@
             }
         },
         "openpgp": {
-            "version": "npm:@protontech/openpgp@5.11.0",
-            "resolved": "https://registry.npmjs.org/@protontech/openpgp/-/openpgp-5.11.0.tgz",
-            "integrity": "sha512-U6I0B66kwGs9hczSbRKGIEDOPfJSmF4Ncf2RBWsRHuF0t5vR0rX8jaBf0tlAqHAGfhr+6PySN0m5nJo2XmF/wA==",
+            "version": "npm:@protontech/openpgp@5.11.1-0",
+            "resolved": "https://registry.npmjs.org/@protontech/openpgp/-/openpgp-5.11.1-0.tgz",
+            "integrity": "sha512-FdKcZVpDXCW9ER+zLWuFHkEsaWfukf+wbZeO90CgL20Hvjry0ZWe/xw49QSL6Y6C//6d0GRk066sukrBEhAsMg==",
             "requires": {
                 "asn1.js": "^5.0.0"
             }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
         "@openpgp/tweetnacl": "^1.0.3",
         "@openpgp/web-stream-tools": "^0.0.13",
         "jsmimeparser": "npm:@protontech/jsmimeparser@^3.0.1",
-        "openpgp": "npm:@protontech/openpgp@~5.11.0"
+        "openpgp": "npm:@protontech/openpgp@~5.11.1-0"
     },
     "devDependencies": {
         "@types/bn.js": "^5.1.1",

--- a/test/crypto/argon2.spec.ts
+++ b/test/crypto/argon2.spec.ts
@@ -1,0 +1,17 @@
+import { expect } from 'chai';
+import { argon2 } from '../../lib';
+import { ARGON2_PARAMS } from '../../lib/constants';
+import { arrayToHexString, hexStringToArray } from '../../lib/utils';
+
+describe('argon2 key derivation', () => {
+    it('basic test - minimum recommended params', async () => {
+        const expected = '6904f1422410f8360c6538300210a2868f5e80cd88606ec7d6e7e93b49983cea';
+        const passwordBytes = hexStringToArray('0101010101010101010101010101010101010101010101010101010101010101');
+        const tag = await argon2({
+            password: new TextDecoder().decode(passwordBytes),
+            salt: hexStringToArray('0202020202020202020202020202020202020202020202020202020202020202'),
+            params: ARGON2_PARAMS.MINIMUM
+        });
+        expect(arrayToHexString(tag)).to.equal(expected);
+    });
+});


### PR DESCRIPTION
Reusing the wasm module of OpenPGP.js