### PR TITLE
Tests: load stream polyfills if needed (fix Safari 13), add README note about polyfilling requirement

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -14,7 +14,8 @@
     "globals": {
         "window": "readonly",
         "btoa": "readonly",
-        "atob": "readonly"
+        "atob": "readonly",
+        "globalThis": "readonly"
     },
     "env": {
         "es6": true,

--- a/README.md
+++ b/README.md
@@ -98,9 +98,9 @@ const { data: decryptedData, verified } = await decryptMessage({
 to encrypt (and/or sign), pass the stream to `textData` or `binaryData` based on the streamed data type. Similarly, to decrypt and verify, the input options are the same as the non-streaming case. However, if `armoredMessage` (or `binaryMessage`) is a stream, the decryption result needs to be handled differently:
 ```js
 // explicitly loading stream polyfills for legacy browsers is required since v7.2.2
-  if (!globalThis.TransformStream) {
-      await import('web-streams-polyfill/es6');
-  }
+if (!globalThis.TransformStream) {
+  await import('web-streams-polyfill/es6');
+}
 
 const { data: dataStream, verified: verifiedPromise } = await decryptMessage({
   message: await readMessage({ armoredMessage: streamedArmoredMessage }),

--- a/README.md
+++ b/README.md
@@ -97,6 +97,11 @@ const { data: decryptedData, verified } = await decryptMessage({
 **For streamed inputs:**
 to encrypt (and/or sign), pass the stream to `textData` or `binaryData` based on the streamed data type. Similarly, to decrypt and verify, the input options are the same as the non-streaming case. However, if `armoredMessage` (or `binaryMessage`) is a stream, the decryption result needs to be handled differently:
 ```js
+// explicitly loading stream polyfills for legacy browsers is required since v7.2.2
+  if (!globalThis.TransformStream) {
+      await import('web-streams-polyfill/es6');
+  }
+
 const { data: dataStream, verified: verifiedPromise } = await decryptMessage({
   message: await readMessage({ armoredMessage: streamedArmoredMessage }),
   ... // other options

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,7 @@
                 "playwright": "^1.40.0",
                 "ts-loader": "^9.4.1",
                 "typescript": "^4.9.5",
+                "web-streams-polyfill": "^3.3.3",
                 "webpack": "^5.66.0",
                 "webpack-cli": "^4.9.2"
             }
@@ -5624,6 +5625,15 @@
                 "node": ">=10.13.0"
             }
         },
+        "node_modules/web-streams-polyfill": {
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+            "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+            "dev": true,
+            "engines": {
+                "node": ">= 8"
+            }
+        },
         "node_modules/webpack": {
             "version": "5.76.1",
             "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.76.1.tgz",
@@ -10111,6 +10121,12 @@
                 "glob-to-regexp": "^0.4.1",
                 "graceful-fs": "^4.1.2"
             }
+        },
+        "web-streams-polyfill": {
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+            "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+            "dev": true
         },
         "webpack": {
             "version": "5.76.1",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
         "playwright": "^1.40.0",
         "ts-loader": "^9.4.1",
         "typescript": "^4.9.5",
+        "web-streams-polyfill": "^3.3.3",
         "webpack": "^5.66.0",
         "webpack-cli": "^4.9.2"
     }

--- a/test/message/encryptMessage.spec.ts
+++ b/test/message/encryptMessage.spec.ts
@@ -16,8 +16,14 @@ const generateStreamOfData = (): { stream: WebStream<string>, data: string } => 
 
 describe('message encryption and decryption', () => {
     const { minRSABits } = globalConfig;
-    before('downgrade openpgp config', () => {
+
+    before('downgrade openpgp config and load stream polyfills', async () => {
         globalConfig.minRSABits = 512;
+
+        // load stream ponyfills if needed
+        if (!globalThis.TransformStream) {
+            await import('web-streams-polyfill/es6');
+        }
     });
     after('restore openpgp config', async () => {
         globalConfig.minRSABits = minRSABits;

--- a/test/message/encryptMessage.spec.ts
+++ b/test/message/encryptMessage.spec.ts
@@ -16,11 +16,10 @@ const generateStreamOfData = (): { stream: WebStream<string>, data: string } => 
 
 describe('message encryption and decryption', () => {
     const { minRSABits } = globalConfig;
-
     before('downgrade openpgp config and load stream polyfills', async () => {
         globalConfig.minRSABits = 512;
 
-        // load stream ponyfills if needed
+        // load stream polyfills if needed
         if (!globalThis.TransformStream) {
             await import('web-streams-polyfill/es6');
         }


### PR DESCRIPTION
Since v7.2.2, the web-stream-tools version used by pmcrypto diverges from the one of OpenPGP.js, and it does not automatically polyfill streams.
Without polyfilling, some of the lib functions do not work on legacy browsers when streamed inputs are used. Affected functions include those that internally process streams (independently of OpenPGP.js), such as `encryptMessage`.