### PR TITLE
Fix forwarding helpers: accept `date` option and use serverTime instead of local time by default

### DIFF
--- a/test/key/forwarding.spec.ts
+++ b/test/key/forwarding.spec.ts
@@ -3,7 +3,7 @@ import { ec as EllipticCurve } from 'elliptic';
 import BN from 'bn.js';
 
 import { decryptKey, enums, KeyID, PacketList } from '../../lib/openpgp';
-import { generateKey, generateForwardingMaterial, doesKeySupportForwarding, encryptMessage, decryptMessage, readMessage, readKey, readPrivateKey } from '../../lib';
+import { generateKey, generateForwardingMaterial, doesKeySupportForwarding, encryptMessage, decryptMessage, readMessage, readKey, readPrivateKey, serverTime } from '../../lib';
 import { computeProxyParameter, isForwardingKey } from '../../lib/key/forwarding';
 import { hexStringToArray, concatArrays, arrayToHexString } from '../../lib/utils';
 
@@ -98,7 +98,7 @@ yGZuVVMAK/ypFfebDf4D/rlEw3cysv213m8aoK8nAUO8xQX3XQq3Sg+EGm0BNV8E
         const charlieKey = await readKey({ armoredKey: forwardeeKey.armor() }); // ensure key is correctly serialized and parsed
 
         // Check subkey differences
-        const bobSubkey = await bobKey.getEncryptionKey();
+        const bobSubkey = await bobKey.getEncryptionKey(undefined, serverTime());
         const charlieSubkey = charlieKey.subkeys[0];
 
         expect(charlieSubkey.bindingSignatures[0].keyFlags![0]).to.equal(enums.keyFlags.forwardedCommunication);

--- a/test/key/utils.spec.ts
+++ b/test/key/utils.spec.ts
@@ -10,7 +10,8 @@ import {
     getMatchingKey,
     generateSessionKeyForAlgorithm,
     generateSessionKey,
-    getSHA256Fingerprints
+    getSHA256Fingerprints,
+    serverTime
 } from '../../lib';
 
 describe('key utils', () => {
@@ -39,7 +40,7 @@ describe('key utils', () => {
             userIDs: [{ name: 'name', email: 'email@test.com' }],
             format: 'object'
         });
-        const now = new Date();
+        const now = serverTime();
         expect(Math.abs(+privateKey.getCreationTime() - +now) < 24 * 3600).to.be.true;
     });
 
@@ -48,7 +49,7 @@ describe('key utils', () => {
             userIDs: [{ name: 'name', email: 'email@test.com' }],
             format: 'object'
         });
-        const { selfCertification } = await privateKey.getPrimaryUser();
+        const { selfCertification } = await privateKey.getPrimaryUser(serverTime());
         expect(selfCertification.preferredSymmetricAlgorithms).to.include(enums.symmetric.aes256);
         expect(selfCertification.preferredHashAlgorithms).to.include(enums.hash.sha256);
         expect(selfCertification.preferredCompressionAlgorithms).to.include(enums.compression.zlib);
@@ -70,7 +71,7 @@ describe('key utils', () => {
     });
 
     it('isExpiredKey - it can correctly detect an expired key', async () => {
-        const now = new Date();
+        const now = serverTime();
         // key expires in one second
         const { privateKey: expiringKey } = await generateKey({
             userIDs: [{ name: 'name', email: 'email@test.com' }],
@@ -93,7 +94,7 @@ describe('key utils', () => {
 
     it('isRevokedKey - it can correctly detect a revoked key', async () => {
         const past = new Date(0);
-        const now = new Date();
+        const now = serverTime();
 
         const { privateKey: key, revocationCertificate } = await generateKey({
             userIDs: [{ name: 'name', email: 'email@test.com' }],

--- a/test/message/context.spec.ts
+++ b/test/message/context.spec.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { verifyMessage, signMessage, generateKey, readSignature, readMessage, decryptMessage, encryptMessage, readKey, ContextError } from '../../lib';
+import { verifyMessage, signMessage, generateKey, readSignature, readMessage, decryptMessage, encryptMessage, readKey, ContextError, serverTime } from '../../lib';
 import { VERIFICATION_STATUS } from '../../lib/constants';
 
 // verification without passing context should fail
@@ -233,7 +233,7 @@ describe('context', () => {
     });
 
     it('does not verify a message without context based on cutoff date (`expectFrom`)', async () => {
-        const now = new Date();
+        const now = serverTime();
         const nextHour = new Date(+now + (3600 * 1000));
         const { privateKey, publicKey } = await generateKey({
             userIDs: [{ name: 'name', email: 'email@test.com' }],

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,7 +1,12 @@
 import { use as chaiUse } from 'chai';
 import * as chaiAsPromised from 'chai-as-promised';
 
-import { init } from '../lib';
+import { init, updateServerTime } from '../lib';
 
 chaiUse(chaiAsPromised);
-before(init);
+before(() => {
+    // set server time in the future to spot functions that use local time unexpectedly
+    const HOUR = 3600 * 1000;
+    updateServerTime(new Date(Date.now() + HOUR));
+    init();
+});


### PR DESCRIPTION
`generateForwardingMaterial`, `doesKeySupportForwarding`, and `isForwardingKey` now accept a date as input, and fallback to the server time by default.

Previously, the functions would use local time to filter encryption keys, meaning wrong results might be returned with local time in the future compared to key creation time.