### PR TITLE
`argon2`: reload wasm module after timeout when using memory heavy params

### DIFF
--- a/lib/crypto/argon2.ts
+++ b/lib/crypto/argon2.ts
@@ -12,8 +12,36 @@ export interface Argon2Options {
     params: Argon2Params
 }
 
+// We manually reload the module if no memory-heavy (128MB+) argon2 computation has been requested in a while,
+// to deallocate the memory.
+// This is better than reloading the module every time (automatically done if the memory exceeds `Argon2S2K.ARGON2_WASM_MEMORY_THRESHOLD_RELOAD`),
+// as doing so comes with a performance hit.
+const SECOND = 1000;
+const TimeoutHandler = {
+    id: undefined,
+    cancelReloadingTimeout: (memoryExponent: number) => (
+        memoryExponent > ARGON2_PARAMS.MINIMUM.memoryExponent && clearTimeout(TimeoutHandler.id)
+    ),
+    setupReloadingTimeout: (memoryExponent: number) => {
+        const shouldReloadAfterTimeout = memoryExponent > ARGON2_PARAMS.MINIMUM.memoryExponent &&
+            memoryExponent < Argon2S2K.ARGON2_WASM_MEMORY_THRESHOLD_RELOAD;
+        // @ts-ignore NodeJS.Timeout typedef interfering
+        TimeoutHandler.id = shouldReloadAfterTimeout ?
+            setTimeout(
+                () => Argon2S2K.reloadWasmModule(),
+                10 * SECOND
+            ) as any as number
+            : undefined;
+    }
+};
+
 export async function argon2({ password, salt, params = ARGON2_PARAMS.RECOMMENDED }: Argon2Options) {
+    TimeoutHandler.cancelReloadingTimeout(params.memoryExponent);
+
     const s2k = new Argon2S2K({ ...defaultConfig, s2kArgon2Params: params });
     s2k.salt = salt;
-    return s2k.produceKey(password, params.tagLength);
+    const result = await s2k.produceKey(password, params.tagLength);
+
+    TimeoutHandler.setupReloadingTimeout(params.memoryExponent);
+    return result;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
                 "@openpgp/tweetnacl": "^1.0.3",
                 "@openpgp/web-stream-tools": "^0.0.13",
                 "jsmimeparser": "npm:@protontech/jsmimeparser@^3.0.1",
-                "openpgp": "npm:@protontech/openpgp@~5.11.1-0"
+                "openpgp": "larabr/openpgpjs#argon2-expose-wasm-module-reload"
             },
             "devDependencies": {
                 "@types/bn.js": "^5.1.1",
@@ -4485,9 +4485,9 @@
         },
         "node_modules/openpgp": {
             "name": "@protontech/openpgp",
-            "version": "5.11.1-0",
-            "resolved": "https://registry.npmjs.org/@protontech/openpgp/-/openpgp-5.11.1-0.tgz",
-            "integrity": "sha512-FdKcZVpDXCW9ER+zLWuFHkEsaWfukf+wbZeO90CgL20Hvjry0ZWe/xw49QSL6Y6C//6d0GRk066sukrBEhAsMg==",
+            "version": "5.11.1",
+            "resolved": "git+ssh://git@github.com/larabr/openpgpjs.git#4bc84bc0318ce9889be826638ab52f8aec334d22",
+            "license": "LGPL-3.0+",
             "dependencies": {
                 "asn1.js": "^5.0.0"
             },
@@ -9326,9 +9326,8 @@
             }
         },
         "openpgp": {
-            "version": "npm:@protontech/openpgp@5.11.1-0",
-            "resolved": "https://registry.npmjs.org/@protontech/openpgp/-/openpgp-5.11.1-0.tgz",
-            "integrity": "sha512-FdKcZVpDXCW9ER+zLWuFHkEsaWfukf+wbZeO90CgL20Hvjry0ZWe/xw49QSL6Y6C//6d0GRk066sukrBEhAsMg==",
+            "version": "git+ssh://git@github.com/larabr/openpgpjs.git#4bc84bc0318ce9889be826638ab52f8aec334d22",
+            "from": "openpgp@larabr/openpgpjs#argon2-expose-wasm-module-reload",
             "requires": {
                 "asn1.js": "^5.0.0"
             }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
         "@openpgp/tweetnacl": "^1.0.3",
         "@openpgp/web-stream-tools": "^0.0.13",
         "jsmimeparser": "npm:@protontech/jsmimeparser@^3.0.1",
-        "openpgp": "npm:@protontech/openpgp@~5.11.1-0"
+        "openpgp": "larabr/openpgpjs#argon2-expose-wasm-module-reload"
     },
     "devDependencies": {
         "@types/bn.js": "^5.1.1",


### PR DESCRIPTION
We manually reload the module if no memory-heavy (128MB+) argon2 computation has been requested in a while, to deallocate the memory.
This is better than reloading the module every time (automatically done if the memory exceeds `Argon2S2K.ARGON2_WASM_MEMORY_THRESHOLD_RELOAD`), as doing so comes with a performance hit.