### PR TITLE
`verify/decryptMessage`: rename `verified` to `verificationStatus`

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ To decrypt and verify (non-streamed input):
 const senderPublicKey = await readKey(...);
 const recipientPrivateKey = await decryptKey(...);
 
-const { data: decryptedData, verified } = await decryptMessage({
+const { data: decryptedData, verificationStatus } = await decryptMessage({
   message: await readMessage({ armoredMessage }), // or `binaryMessage`
   encryptedSignature: await readMessage({ armoredMessage: armoredEncryptedSignature })
   decryptionKeys: recipientPrivateKey // and/or 'passwords'
@@ -71,14 +71,14 @@ if (!globalThis.TransformStream) {
   await import('web-streams-polyfill/es6');
 }
 
-const { data: dataStream, verified: verifiedPromise } = await decryptMessage({
+const { data: dataStream, verificationStatus: verifiedPromise } = await decryptMessage({
   message: await readMessage({ armoredMessage: streamedArmoredMessage }),
   ... // other options
 });
 
 // you need to read `dataStream` before resolving `verifiedPromise`, even if you do not need the decrypted data
 const decryptedData = await readToEnd(dataStream);
-const verificationStatus = await verified;
+const verificationStatus = await verificationStatus;
 ```
 </details>
 

--- a/lib/message/decrypt.js
+++ b/lib/message/decrypt.js
@@ -12,7 +12,9 @@ export default async function decryptMessage({
     config = {},
     ...options
 }) {
-    if (signatureContext && (options.verificationKeys === undefined || options.verificationKeys.length === 0)) {
+    if (signatureContext &&
+        (options.verificationKeys === undefined ||
+            (options.verificationKeys instanceof Array && options.verificationKeys.length === 0))) {
         // sanity check to catch mistakes in case library users wrongly consider the `context` to be
         // applied into e.g. the AEAD associated data
         throw new Error('Unexpected `signatureContext` input without any `verificationKeys` provided');

--- a/lib/message/decrypt.js
+++ b/lib/message/decrypt.js
@@ -38,12 +38,12 @@ export default async function decryptMessage({
         const decryptionResult = await decrypt(sanitizedOptions);
         const verificationResult = handleVerificationResult(decryptionResult, signatureContext, options.expectSigned);
 
-        let verified = verificationResult.then((result) => result.verified);
+        let verificationStatus = verificationResult.then((result) => result.verificationStatus);
         let verifiedSignatures = verificationResult.then((result) => result.signatures);
         let verificationErrors = verificationResult.then((result) => result.errors);
 
         if (!isStream(decryptionResult.data)) {
-            verified = await verified;
+            verificationStatus = await verificationStatus;
             verifiedSignatures = await verifiedSignatures;
             verificationErrors = await verificationErrors;
         }
@@ -51,7 +51,7 @@ export default async function decryptMessage({
         return {
             data: decryptionResult.data,
             filename: decryptionResult.filename,
-            verified,
+            verificationStatus,
             signatures: verifiedSignatures,
             verificationErrors
         };

--- a/lib/message/verify.d.ts
+++ b/lib/message/verify.d.ts
@@ -8,6 +8,7 @@ import type {
 } from '../openpgp';
 import type { VERIFICATION_STATUS } from '../constants';
 import type { ContextVerificationOptions } from './context';
+import type { MaybeWebStream } from '../pmcrypto';
 
 // Streaming not supported when verifying detached signatures
 export interface VerifyOptionsPmcrypto<T extends Data> extends Omit<VerifyOptions, 'message'> {
@@ -19,7 +20,7 @@ export interface VerifyOptionsPmcrypto<T extends Data> extends Omit<VerifyOption
 
 export interface VerifyMessageResult<DataType extends openpgp_VerifyMessageResult['data'] = Data> {
     data: DataType;
-    verified: VERIFICATION_STATUS;
+    verificationStatus: VERIFICATION_STATUS;
     signatures: OpenPGPSignature[];
     signatureTimestamp: Date | null;
     errors?: Error[];
@@ -33,7 +34,7 @@ export function verifyMessage<DataType extends Data, FormatType extends VerifyOp
         VerifyMessageResult<Uint8Array> :
     never
 >;
-export function handleVerificationResult<DataType extends Data>(
+export function handleVerificationResult<DataType extends MaybeWebStream<Data>>(
     verificationResult: openpgp_VerifyMessageResult<DataType>,
     signatureContext?: ContextVerificationOptions,
     expectSigned?: boolean

--- a/lib/message/verify.js
+++ b/lib/message/verify.js
@@ -21,7 +21,7 @@ const { NOT_SIGNED, SIGNED_AND_VALID, SIGNED_AND_INVALID } = VERIFICATION_STATUS
  * @param {Boolean} expectSigned - whether a valid signature is expected; it causes the function to throw otherwise
  * @returns {{
  *     data: Uint8Array|string|ReadableStream|NodeStream - message data,
- *     verified: constants.VERIFICATION_STATUS - message verification status,
+ *     verificationStatus: constants.VERIFICATION_STATUS - message verification status,
  *     signatures: openpgp.signature.Signature[] - message signatures,
  *     signatureTimestamp: Date|null - creation date of the first valid message signature, or null if all signatures are missing or invalid,
  *     errors: Error[]|undefined - verification errors if all signatures are invalid
@@ -71,7 +71,7 @@ export async function handleVerificationResult(verificationResult, signatureCont
 
     return {
         data,
-        verified: verificationStatus,
+        verificationStatus,
         signatures,
         signatureTimestamp,
         errors: verificationStatus === SIGNED_AND_INVALID ? errors : undefined
@@ -87,7 +87,7 @@ export async function handleVerificationResult(verificationResult, signatureCont
  *
  * @returns {Promise<Object>}  Verification result in the form: {
  *     data: Uint8Array|string|ReadableStream - message data,
- *     verified: constants.VERIFICATION_STATUS - message verification status,
+ *     verificationStatus: VERIFICATION_STATUS - message verification status,
  *     signatures: openpgp.Signature[] - message signatures,
  *     signatureTimestamp: Date|null - creation date of the first valid message signature, or null if all signatures are missing or invalid,
  *     errors: Error[]|undefined - verification errors if all signatures are invalid
@@ -124,7 +124,7 @@ export async function verifyMessage({
  *
  * @returns {Promise<Object>}  Verification result in the form: {
  *     data: Uint8Array|string|ReadableStream - message data,
- *     verified: constants.VERIFICATION_STATUS - message verification status,
+ *     verificationStatus: VERIFICATION_STATUS - message verification status,
  *     signatures: openpgp.Signature[] - message signatures,
  *     signatureTimestamp: Date|null - creation date of the first valid message signature, or null if all signatures are missing or invalid,
  *     errors: Error[]|undefined - verification errors if all signatures are invalid

--- a/lib/pmcrypto.d.ts
+++ b/lib/pmcrypto.d.ts
@@ -77,7 +77,7 @@ export interface DecryptResultPmcrypto<DataType extends openpgp_DecryptMessageRe
     data: DataType;
     signatures: DataType extends WebStream<Data> ? Promise<OpenPGPSignature[]> : OpenPGPSignature[];
     filename: string;
-    verified: DataType extends WebStream<Data> ? Promise<VERIFICATION_STATUS> : VERIFICATION_STATUS;
+    verificationStatus: DataType extends WebStream<Data> ? Promise<VERIFICATION_STATUS> : VERIFICATION_STATUS;
     verificationErrors?: DataType extends WebStream<Data> ? Promise<Error[]> : Error[];
 }
 

--- a/test/config.spec.ts
+++ b/test/config.spec.ts
@@ -94,11 +94,11 @@ EoSmib14fiYL0eQTz4I1XJ9OCVVZcaoFZzKnlQc=
         const key = await readKey({ armoredKey: oldReformattedKey });
 
         // since the key is valid at the current time, the message should be verifiable if the `config` allows it
-        const { verified } = await verifyMessage({
+        const { verificationStatus } = await verifyMessage({
             textData: 'plaintext',
             signature: await readSignature({ armoredSignature }),
             verificationKeys: key
         });
-        expect(verified).to.equal(VERIFICATION_STATUS.SIGNED_AND_VALID);
+        expect(verificationStatus).to.equal(VERIFICATION_STATUS.SIGNED_AND_VALID);
     });
 });

--- a/test/message/context.spec.ts
+++ b/test/message/context.spec.ts
@@ -49,9 +49,9 @@ describe('context', () => {
             verificationKeys: [publicKey]
         });
 
-        expect(verificationValidContext.verified).to.equal(VERIFICATION_STATUS.SIGNED_AND_VALID);
-        expect(verificationWrongContext.verified).to.equal(VERIFICATION_STATUS.SIGNED_AND_INVALID);
-        expect(verificationMissingContext.verified).to.equal(VERIFICATION_STATUS.SIGNED_AND_INVALID);
+        expect(verificationValidContext.verificationStatus).to.equal(VERIFICATION_STATUS.SIGNED_AND_VALID);
+        expect(verificationWrongContext.verificationStatus).to.equal(VERIFICATION_STATUS.SIGNED_AND_INVALID);
+        expect(verificationMissingContext.verificationStatus).to.equal(VERIFICATION_STATUS.SIGNED_AND_INVALID);
         // check errors
         expect(verificationValidContext.errors).to.be.undefined;
         expect(verificationWrongContext.errors).to.have.length(1);
@@ -101,10 +101,10 @@ describe('context', () => {
             verificationKeys: [publicKey]
         });
 
-        expect(verificationValidContext.verified).to.equal(VERIFICATION_STATUS.SIGNED_AND_VALID);
-        expect(verificationWrongContext.verified).to.equal(VERIFICATION_STATUS.SIGNED_AND_INVALID);
-        expect(verificationWrongContextNotRequired.verified).to.equal(VERIFICATION_STATUS.SIGNED_AND_INVALID);
-        expect(verificationMissingContext.verified).to.equal(VERIFICATION_STATUS.SIGNED_AND_VALID);
+        expect(verificationValidContext.verificationStatus).to.equal(VERIFICATION_STATUS.SIGNED_AND_VALID);
+        expect(verificationWrongContext.verificationStatus).to.equal(VERIFICATION_STATUS.SIGNED_AND_INVALID);
+        expect(verificationWrongContextNotRequired.verificationStatus).to.equal(VERIFICATION_STATUS.SIGNED_AND_INVALID);
+        expect(verificationMissingContext.verificationStatus).to.equal(VERIFICATION_STATUS.SIGNED_AND_VALID);
         // check errors
         expect(verificationValidContext.errors).to.be.undefined;
         expect(verificationWrongContext.errors).to.have.length(1);
@@ -147,9 +147,9 @@ describe('context', () => {
             verificationKeys: publicKey
         });
 
-        expect(decryptionValidContext.verified).to.equal(VERIFICATION_STATUS.SIGNED_AND_VALID);
-        expect(decryptionWrongContext.verified).to.equal(VERIFICATION_STATUS.SIGNED_AND_INVALID);
-        expect(decryptionMissingContext.verified).to.equal(VERIFICATION_STATUS.SIGNED_AND_INVALID);
+        expect(decryptionValidContext.verificationStatus).to.equal(VERIFICATION_STATUS.SIGNED_AND_VALID);
+        expect(decryptionWrongContext.verificationStatus).to.equal(VERIFICATION_STATUS.SIGNED_AND_INVALID);
+        expect(decryptionMissingContext.verificationStatus).to.equal(VERIFICATION_STATUS.SIGNED_AND_INVALID);
         // check errors
         expect(decryptionValidContext.verificationErrors).to.be.undefined;
         expect(decryptionWrongContext.verificationErrors).to.have.length(1);
@@ -195,9 +195,9 @@ describe('context', () => {
             verificationKeys: publicKey
         });
 
-        expect(decryptionValidContext.verified).to.equal(VERIFICATION_STATUS.SIGNED_AND_VALID);
-        expect(decryptionWrongContext.verified).to.equal(VERIFICATION_STATUS.SIGNED_AND_INVALID);
-        expect(decryptionMissingContext.verified).to.equal(VERIFICATION_STATUS.SIGNED_AND_INVALID);
+        expect(decryptionValidContext.verificationStatus).to.equal(VERIFICATION_STATUS.SIGNED_AND_VALID);
+        expect(decryptionWrongContext.verificationStatus).to.equal(VERIFICATION_STATUS.SIGNED_AND_INVALID);
+        expect(decryptionMissingContext.verificationStatus).to.equal(VERIFICATION_STATUS.SIGNED_AND_INVALID);
         // check errors
         expect(decryptionValidContext.verificationErrors).to.be.undefined;
         expect(decryptionWrongContext.verificationErrors).to.have.length(1);
@@ -256,8 +256,8 @@ sJFJxllC0j4wHCOS9uiSYsZ/pWCqxX/3sFh4VBFOpr0HAA==
             signatureContext: { value: 'test-context', required: false }
         });
 
-        expect(verificationExpectedContext.verified).to.equal(VERIFICATION_STATUS.SIGNED_AND_INVALID);
-        expect(verificationNoExpectedContext.verified).to.equal(VERIFICATION_STATUS.SIGNED_AND_VALID);
+        expect(verificationExpectedContext.verificationStatus).to.equal(VERIFICATION_STATUS.SIGNED_AND_INVALID);
+        expect(verificationNoExpectedContext.verificationStatus).to.equal(VERIFICATION_STATUS.SIGNED_AND_VALID);
 
         expect(verificationNoExpectedContext.errors).to.be.undefined;
         expect(verificationExpectedContext.errors).to.have.length(1);
@@ -295,8 +295,8 @@ sJFJxllC0j4wHCOS9uiSYsZ/pWCqxX/3sFh4VBFOpr0HAA==
             signatureContext: { value: 'test-context', requiredAfter: nextHour }
         });
 
-        expect(verificationExpectedContext.verified).to.equal(VERIFICATION_STATUS.SIGNED_AND_INVALID);
-        expect(verificationNoExpectedContext.verified).to.equal(VERIFICATION_STATUS.SIGNED_AND_VALID);
+        expect(verificationExpectedContext.verificationStatus).to.equal(VERIFICATION_STATUS.SIGNED_AND_INVALID);
+        expect(verificationNoExpectedContext.verificationStatus).to.equal(VERIFICATION_STATUS.SIGNED_AND_VALID);
 
         expect(verificationNoExpectedContext.errors).to.be.undefined;
         expect(verificationExpectedContext.errors).to.have.length(1);
@@ -343,7 +343,7 @@ sj39B18qvvnS11F+AAB7igEAqwmlDXMzeNNLc3skdyQWZoP0fPyI/ol7pMa+
             verificationKeys: publicKey
         });
 
-        expect(verificationWithContext.verified).to.equal(VERIFICATION_STATUS.SIGNED_AND_INVALID);
-        expect(verificationWithoutContext.verified).to.equal(VERIFICATION_STATUS.SIGNED_AND_VALID);
+        expect(verificationWithContext.verificationStatus).to.equal(VERIFICATION_STATUS.SIGNED_AND_INVALID);
+        expect(verificationWithoutContext.verificationStatus).to.equal(VERIFICATION_STATUS.SIGNED_AND_VALID);
     });
 });

--- a/test/message/encryptMessage.spec.ts
+++ b/test/message/encryptMessage.spec.ts
@@ -34,13 +34,13 @@ describe('message encryption and decryption', () => {
             encryptionKeys: [decryptedPrivateKey.toPublic()],
             signingKeys: [decryptedPrivateKey]
         });
-        const { data: decrypted, verified } = await decryptMessage({
+        const { data: decrypted, verificationStatus } = await decryptMessage({
             message: await readMessage({ armoredMessage: encrypted }),
             verificationKeys: [decryptedPrivateKey.toPublic()],
             decryptionKeys: [decryptedPrivateKey]
         });
         expect(decrypted).to.equal('Hello world!');
-        expect(verified).to.equal(VERIFICATION_STATUS.SIGNED_AND_VALID);
+        expect(verificationStatus).to.equal(VERIFICATION_STATUS.SIGNED_AND_VALID);
     });
 
     it('it can encrypt and decrypt a binary message', async () => {
@@ -51,14 +51,14 @@ describe('message encryption and decryption', () => {
             encryptionKeys: [decryptedPrivateKey.toPublic()],
             signingKeys: [decryptedPrivateKey]
         });
-        const { data: decrypted, verified } = await decryptMessage({
+        const { data: decrypted, verificationStatus } = await decryptMessage({
             message: await readMessage({ armoredMessage: encrypted }),
             verificationKeys: [decryptedPrivateKey.toPublic()],
             decryptionKeys: [decryptedPrivateKey],
             format: 'binary'
         });
         expect(decrypted).to.deep.equal(stringToUtf8Array('Hello world!'));
-        expect(verified).to.equal(VERIFICATION_STATUS.SIGNED_AND_VALID);
+        expect(verificationStatus).to.equal(VERIFICATION_STATUS.SIGNED_AND_VALID);
     });
 
     it('it does not encrypt with SEIPDv2 by default', async () => {
@@ -107,13 +107,13 @@ describe('message encryption and decryption', () => {
             signingKeys: [decryptedPrivateKey],
             sessionKey
         });
-        const { data: decrypted, verified } = await decryptMessage({
+        const { data: decrypted, verificationStatus } = await decryptMessage({
             message: await readMessage({ armoredMessage: encrypted }),
             verificationKeys: [decryptedPrivateKey.toPublic()],
             sessionKeys: sessionKey
         });
         expect(decrypted).to.equal('Hello world!');
-        expect(verified).to.equal(VERIFICATION_STATUS.SIGNED_AND_VALID);
+        expect(verificationStatus).to.equal(VERIFICATION_STATUS.SIGNED_AND_VALID);
     });
 
     it('it can encrypt a message with a session key from `generateSessionKey`', async () => {
@@ -126,12 +126,12 @@ describe('message encryption and decryption', () => {
             encryptionKeys: decryptedPrivateKey.toPublic(),
             sessionKey
         });
-        const { data: decrypted, verified } = await decryptMessage({
+        const { data: decrypted, verificationStatus } = await decryptMessage({
             message: await readMessage({ armoredMessage: encrypted }),
             decryptionKeys: decryptedPrivateKey
         });
         expect(decrypted).to.equal('Hello world!');
-        expect(verified).to.equal(VERIFICATION_STATUS.NOT_SIGNED);
+        expect(verificationStatus).to.equal(VERIFICATION_STATUS.NOT_SIGNED);
     });
 
     it('it does not compress a message by default', async () => {
@@ -188,20 +188,20 @@ describe('message encryption and decryption', () => {
             signingKeys: [decryptedPrivateKey],
             detached: true
         });
-        const { data: decrypted, verified } = await decryptMessage({
+        const { data: decrypted, verificationStatus } = await decryptMessage({
             message: await readMessage({ armoredMessage: encrypted }),
             signature: await readSignature({ armoredSignature }),
             verificationKeys: [decryptedPrivateKey.toPublic()],
             decryptionKeys: [decryptedPrivateKey]
         });
         expect(decrypted).to.equal('Hello world!');
-        expect(verified).to.equal(VERIFICATION_STATUS.SIGNED_AND_VALID);
-        const { verified: verifiedAgain } = await verifyMessage({
+        expect(verificationStatus).to.equal(VERIFICATION_STATUS.SIGNED_AND_VALID);
+        const { verificationStatus: verificationStatusAgain } = await verifyMessage({
             textData: 'Hello world!',
             signature: await readSignature({ armoredSignature }),
             verificationKeys: [decryptedPrivateKey.toPublic()]
         });
-        expect(verifiedAgain).to.equal(VERIFICATION_STATUS.SIGNED_AND_VALID);
+        expect(verificationStatusAgain).to.equal(VERIFICATION_STATUS.SIGNED_AND_VALID);
     });
 
     it('it can encrypt and decrypt a message with an encrypted detached signature', async () => {
@@ -217,14 +217,14 @@ describe('message encryption and decryption', () => {
         const parsedEncryptedSignature = await readMessage({ armoredMessage: encryptedSignature });
         expect(parsedEncryptedSignature.getSigningKeyIDs()).to.have.length(0); // the encrypted message containing the signature should not be signed
 
-        const { data: decrypted, verified } = await decryptMessage({
+        const { data: decrypted, verificationStatus } = await decryptMessage({
             message: await readMessage({ armoredMessage: encrypted }),
             encryptedSignature: parsedEncryptedSignature,
             verificationKeys: [decryptedPrivateKey.toPublic()],
             decryptionKeys: [decryptedPrivateKey]
         });
         expect(decrypted).to.equal('Hello world!');
-        expect(verified).to.equal(VERIFICATION_STATUS.SIGNED_AND_VALID);
+        expect(verificationStatus).to.equal(VERIFICATION_STATUS.SIGNED_AND_VALID);
     });
 
     it('it can encrypt and decrypt a message with session key without setting returnSessionKey with a detached signature', async () => {
@@ -241,14 +241,14 @@ describe('message encryption and decryption', () => {
             detached: true,
             sessionKey
         });
-        const { data: decrypted, verified } = await decryptMessage({
+        const { data: decrypted, verificationStatus } = await decryptMessage({
             message: await readMessage({ armoredMessage: encrypted }),
             verificationKeys: [decryptedPrivateKey.toPublic()],
             encryptedSignature: await readMessage({ armoredMessage: encryptedSignature }),
             sessionKeys: sessionKey
         });
         expect(decrypted).to.equal('Hello world!');
-        expect(verified).to.equal(VERIFICATION_STATUS.SIGNED_AND_VALID);
+        expect(verificationStatus).to.equal(VERIFICATION_STATUS.SIGNED_AND_VALID);
     });
 
     it('it can encrypt and decrypt a streamed message with an unencrypted detached signature (format = armored)', async () => {
@@ -268,7 +268,7 @@ describe('message encryption and decryption', () => {
             format: 'armored',
             detached: true
         });
-        const { data: decrypted, verified } = await decryptMessage({
+        const { data: decrypted, verificationStatus } = await decryptMessage({
             message: await readMessage({ armoredMessage: await readToEnd(encrypted) }),
             encryptedSignature: await readMessage({ armoredMessage: encryptedSignature }),
             sessionKeys: sessionKey,
@@ -276,7 +276,7 @@ describe('message encryption and decryption', () => {
             format: 'binary'
         });
         expect(utf8ArrayToString(await readToEnd(decrypted))).to.equal(inputData);
-        expect(verified).to.equal(VERIFICATION_STATUS.SIGNED_AND_VALID);
+        expect(verificationStatus).to.equal(VERIFICATION_STATUS.SIGNED_AND_VALID);
     });
 
     it('it can encrypt and decrypt a streamed message with an unencrypted detached signature (format = binary)', async () => {
@@ -296,7 +296,7 @@ describe('message encryption and decryption', () => {
             format: 'binary',
             detached: true
         });
-        const { data: decrypted, verified } = await decryptMessage({
+        const { data: decrypted, verificationStatus } = await decryptMessage({
             message: await readMessage({ binaryMessage: await readToEnd(encrypted) as Uint8Array }),
             encryptedSignature: await readMessage({ binaryMessage: encryptedSignature }),
             sessionKeys: sessionKey,
@@ -304,7 +304,7 @@ describe('message encryption and decryption', () => {
             format: 'binary'
         });
         expect(utf8ArrayToString(await readToEnd(decrypted))).to.equal(inputData);
-        expect(verified).to.equal(VERIFICATION_STATUS.SIGNED_AND_VALID);
+        expect(verificationStatus).to.equal(VERIFICATION_STATUS.SIGNED_AND_VALID);
     });
 
     it('it can encrypt and decrypt a binary streamed message with an encrypted detached signature', async () => {
@@ -326,7 +326,7 @@ describe('message encryption and decryption', () => {
         });
         const encryptedArmoredMessage = await readToEnd(encrypted);
 
-        const { data: decrypted, verified } = await decryptMessage({
+        const { data: decrypted, verificationStatus } = await decryptMessage({
             message: await readMessage({ armoredMessage: toStream(encryptedArmoredMessage) as WebStream<string> }),
             encryptedSignature: await readMessage({ armoredMessage: encryptedSignature }),
             sessionKeys: sessionKey,
@@ -334,7 +334,7 @@ describe('message encryption and decryption', () => {
             format: 'binary'
         });
         expect(utf8ArrayToString(await readToEnd(decrypted))).to.equal(inputData);
-        expect(await verified).to.equal(VERIFICATION_STATUS.SIGNED_AND_VALID);
+        expect(await verificationStatus).to.equal(VERIFICATION_STATUS.SIGNED_AND_VALID);
     });
 
     it('it can encrypt and decrypt a binary streamed message with in-message signature', async () => {
@@ -353,14 +353,14 @@ describe('message encryption and decryption', () => {
             sessionKey,
             format: 'object'
         });
-        const { data: decrypted, verified } = await decryptMessage({
+        const { data: decrypted, verificationStatus } = await decryptMessage({
             message: encrypted,
             sessionKeys: sessionKey,
             verificationKeys: [decryptedPrivateKey.toPublic()],
             format: 'binary'
         });
         expect(utf8ArrayToString(await readToEnd(decrypted))).to.equal(inputData);
-        expect(await verified).to.equal(VERIFICATION_STATUS.SIGNED_AND_VALID);
+        expect(verificationStatus).to.equal(VERIFICATION_STATUS.SIGNED_AND_VALID);
     });
 
     it('it can decrypt and verify a message ten seconds in the future', async () => {
@@ -383,13 +383,13 @@ describe('message encryption and decryption', () => {
             date: tenSecondsInTheFuture,
             format: 'object'
         });
-        const { data: decrypted, verified } = await decryptMessage({
+        const { data: decrypted, verificationStatus } = await decryptMessage({
             message: encrypted,
             sessionKeys: sessionKey,
             verificationKeys: [decryptedPrivateKey.toPublic()]
         });
 
         expect(decrypted).to.equal(data);
-        expect(await verified).to.equal(VERIFICATION_STATUS.SIGNED_AND_VALID);
+        expect(verificationStatus).to.equal(VERIFICATION_STATUS.SIGNED_AND_VALID);
     });
 });

--- a/test/message/processMIME.spec.ts
+++ b/test/message/processMIME.spec.ts
@@ -42,13 +42,13 @@ Import HTML cöntäct//Subjεέςτ//
     });
 
     it('it can process multipart/signed mime messages and verify the signature', async () => {
-        const { body, verified, signatures, attachments, encryptedSubject } = await processMIME(
+        const { body, verificationStatus, signatures, attachments, encryptedSubject } = await processMIME(
             {
                 data: multipartSignedMessage,
                 verificationKeys: await readKey({ armoredKey: key })
             }
         );
-        expect(verified).to.equal(VERIFICATION_STATUS.SIGNED_AND_VALID);
+        expect(verificationStatus).to.equal(VERIFICATION_STATUS.SIGNED_AND_VALID);
         expect(signatures.length).to.equal(1);
         expect(signatures[0]).to.be.instanceOf(Signature);
         expect(body).to.equal(multipartSignedMessageBody);
@@ -57,38 +57,38 @@ Import HTML cöntäct//Subjεέςτ//
     });
 
     it('it can process multipart/signed mime messages and verify the signature with extra parts at the end', async () => {
-        const { body, verified, signatures, attachments } = await processMIME(
+        const { body, verificationStatus, signatures, attachments } = await processMIME(
             {
                 data: extraMultipartSignedMessage,
                 verificationKeys: await readKey({ armoredKey: key })
             }
         );
-        expect(verified).to.equal(VERIFICATION_STATUS.SIGNED_AND_VALID);
+        expect(verificationStatus).to.equal(VERIFICATION_STATUS.SIGNED_AND_VALID);
         expect(body).to.equal('hello');
         expect(signatures.length).to.equal(1);
         expect(attachments.length).to.equal(0);
     });
 
     it('it does not verify invalid messages', async () => {
-        const { verified, body, signatures } = await processMIME(
+        const { verificationStatus, body, signatures } = await processMIME(
             {
                 data: invalidMultipartSignedMessage,
                 verificationKeys: await readKey({ armoredKey: key })
             }
         );
-        expect(verified).to.equal(VERIFICATION_STATUS.NOT_SIGNED);
+        expect(verificationStatus).to.equal(VERIFICATION_STATUS.NOT_SIGNED);
         expect(signatures.length).to.equal(0);
         expect(body).to.equal('message with missing signature');
     });
 
     it('it can parse messages with special characters in the boundary', async () => {
-        const { verified, body, signatures } = await processMIME(
+        const { verificationStatus, body, signatures } = await processMIME(
             {
                 data: multiPartMessageWithSpecialCharacter,
                 verificationKeys: await readKey({ armoredKey: key })
             }
         );
-        expect(verified).to.equal(VERIFICATION_STATUS.SIGNED_AND_VALID);
+        expect(verificationStatus).to.equal(VERIFICATION_STATUS.SIGNED_AND_VALID);
         expect(signatures.length).to.equal(1);
         expect(body).to.equal('hello');
     });
@@ -101,10 +101,10 @@ Import HTML cöntäct//Subjεέςτ//
     });
 
     it('it can parse message with empty signature', async () => {
-        const { body, signatures, verified, attachments } = await processMIME({
+        const { body, signatures, verificationStatus, attachments } = await processMIME({
             data: messageWithEmptySignature
         });
-        expect(verified).to.equal(VERIFICATION_STATUS.NOT_SIGNED);
+        expect(verificationStatus).to.equal(VERIFICATION_STATUS.NOT_SIGNED);
         expect(signatures).to.have.length(0);
         expect(body).to.equal('<div>Hello</div>\n');
         expect(attachments).to.have.length(1); // signature part that failed to parse
@@ -112,11 +112,11 @@ Import HTML cöntäct//Subjεέςτ//
     });
 
     it('it can parse message with text attachment', async () => {
-        const { verified, body, signatures, attachments } = await processMIME({
+        const { verificationStatus, body, signatures, attachments } = await processMIME({
             data: multipartMessageWithAttachment,
             verificationKeys: await readKey({ armoredKey: key })
         });
-        expect(verified).to.equal(VERIFICATION_STATUS.NOT_SIGNED);
+        expect(verificationStatus).to.equal(VERIFICATION_STATUS.NOT_SIGNED);
         expect(signatures.length).to.equal(0);
         expect(body).to.equal('this is the body text\n');
         expect(attachments.length).to.equal(1);
@@ -130,11 +130,11 @@ Import HTML cöntäct//Subjεέςτ//
     });
 
     it('it can parse message with encrypted subject', async () => {
-        const { verified, body, signatures, encryptedSubject } = await processMIME({
+        const { verificationStatus, body, signatures, encryptedSubject } = await processMIME({
             data: multipartMessageWithEncryptedSubject,
             verificationKeys: await readKey({ armoredKey: key })
         });
-        expect(verified).to.equal(VERIFICATION_STATUS.SIGNED_AND_INVALID);
+        expect(verificationStatus).to.equal(VERIFICATION_STATUS.SIGNED_AND_INVALID);
         expect(signatures.length).to.equal(1);
         expect(encryptedSubject).to.equal('Encrypted subject');
         expect(body).to.equal('hello');

--- a/test/message/signMessage.spec.ts
+++ b/test/message/signMessage.spec.ts
@@ -23,7 +23,7 @@ describe('message signing', () => {
             verificationKeys: [publicKey]
         });
 
-        expect(verificationResult.verified).to.equal(VERIFICATION_STATUS.SIGNED_AND_VALID);
+        expect(verificationResult.verificationStatus).to.equal(VERIFICATION_STATUS.SIGNED_AND_VALID);
     });
 
     it('signMessage/verifyMessage - it verifies a text message it has signed (format = binary)', async () => {
@@ -45,7 +45,7 @@ describe('message signing', () => {
             verificationKeys: [publicKey]
         });
 
-        expect(verificationResult.verified).to.equal(VERIFICATION_STATUS.SIGNED_AND_VALID);
+        expect(verificationResult.verificationStatus).to.equal(VERIFICATION_STATUS.SIGNED_AND_VALID);
     });
 
     it('signMessage/verifyMessage - it verifies a binary message it has signed', async () => {
@@ -66,7 +66,7 @@ describe('message signing', () => {
             verificationKeys: [publicKey]
         });
 
-        expect(verificationResult.verified).to.equal(VERIFICATION_STATUS.SIGNED_AND_VALID);
+        expect(verificationResult.verificationStatus).to.equal(VERIFICATION_STATUS.SIGNED_AND_VALID);
     });
 
     it('signMessage/verifyMessage - it normalises a text message with trailing whitespaces', async () => {
@@ -99,7 +99,7 @@ describe('message signing', () => {
             expectSigned: true
         });
 
-        expect(verificationResult.verified).to.equal(VERIFICATION_STATUS.SIGNED_AND_VALID);
+        expect(verificationResult.verificationStatus).to.equal(VERIFICATION_STATUS.SIGNED_AND_VALID);
     });
 
     it('signMessage/verifyMessage - it verifies a streamed message it has signed', async () => {
@@ -130,6 +130,6 @@ describe('message signing', () => {
         });
 
         expect(verificationResult.data).to.equal(inputData);
-        expect(verificationResult.verified).to.equal(VERIFICATION_STATUS.SIGNED_AND_VALID);
+        expect(verificationResult.verificationStatus).to.equal(VERIFICATION_STATUS.SIGNED_AND_VALID);
     });
 });

--- a/test/message/verifyMessage.spec.ts
+++ b/test/message/verifyMessage.spec.ts
@@ -45,13 +45,13 @@ describe('message verification', () => {
     it('verifyMessage - it verifies a message with multiple signatures', async () => {
         const publicKey1 = await readKey({ armoredKey: armoredPublicKey });
         const publicKey2 = await readKey({ armoredKey: armoredPublicKey2 });
-        const { data, verified, signatureTimestamp, signatures, errors } = await verifyMessage({
+        const { data, verificationStatus, signatureTimestamp, signatures, errors } = await verifyMessage({
             textData: 'hello world',
             signature: await readSignature({ armoredSignature: detachedSignatureFromTwoKeys }),
             verificationKeys: [publicKey1, publicKey2]
         });
         expect(data).to.equal('hello world');
-        expect(verified).to.equal(VERIFICATION_STATUS.SIGNED_AND_VALID);
+        expect(verificationStatus).to.equal(VERIFICATION_STATUS.SIGNED_AND_VALID);
         expect(signatures.length).to.equal(2);
         expect(errors).to.be.undefined;
         const signaturePackets = signatures.map(({ packets: [sigPacket] }) => sigPacket);
@@ -61,13 +61,13 @@ describe('message verification', () => {
     it('verifyMessage - it verifies a message with multiple signatures and returns the timestamp of the valid signature', async () => {
         const publicKey1 = await readKey({ armoredKey: armoredPublicKey });
         const publicKey2 = await readKey({ armoredKey: armoredPublicKey2 });
-        const { data, verified, signatureTimestamp, signatures, errors } = await verifyMessage({
+        const { data, verificationStatus, signatureTimestamp, signatures, errors } = await verifyMessage({
             textData: 'hello world',
             signature: await readSignature({ armoredSignature: detachedSignatureFromTwoKeys }),
-            verificationKeys: [publicKey1] // the second public key is missing, expect only one signature to be verified
+            verificationKeys: [publicKey1] // the second public key is missing, expect only one signature to be verificationStatus
         });
         expect(data).to.equal('hello world');
-        expect(verified).to.equal(VERIFICATION_STATUS.SIGNED_AND_VALID);
+        expect(verificationStatus).to.equal(VERIFICATION_STATUS.SIGNED_AND_VALID);
         expect(signatures.length).to.equal(2);
         expect(errors).to.be.undefined;
         const signaturePackets = signatures.map(({ packets: [sigPacket] }) => sigPacket);
@@ -86,12 +86,12 @@ describe('message verification', () => {
             userIDs: [{ name: 'test', email: 'a@b.com' }],
             format: 'object'
         });
-        const { verified, signatureTimestamp, signatures, errors } = await verifyMessage({
+        const { verificationStatus, signatureTimestamp, signatures, errors } = await verifyMessage({
             textData: 'hello world',
             signature: await readSignature({ armoredSignature: detachedSignatureFromTwoKeys }),
             verificationKeys: [wrongPublicKey]
         });
-        expect(verified).to.equal(VERIFICATION_STATUS.SIGNED_AND_INVALID);
+        expect(verificationStatus).to.equal(VERIFICATION_STATUS.SIGNED_AND_INVALID);
         expect(signatures.length).to.equal(2);
         expect(errors).to.not.be.undefined;
         expect(errors!.length).to.equal(2);
@@ -101,12 +101,12 @@ describe('message verification', () => {
 
     it('verifyMessage - it does not verify a message with corrupted signature', async () => {
         const publicKey = await readKey({ armoredKey: armoredPublicKey });
-        const { verified, signatureTimestamp, signatures, errors } = await verifyMessage({
+        const { verificationStatus, signatureTimestamp, signatures, errors } = await verifyMessage({
             textData: 'corrupted',
             signature: await readSignature({ armoredSignature: detachedSignatureFromTwoKeys }),
             verificationKeys: [publicKey]
         });
-        expect(verified).to.equal(VERIFICATION_STATUS.SIGNED_AND_INVALID);
+        expect(verificationStatus).to.equal(VERIFICATION_STATUS.SIGNED_AND_INVALID);
         expect(signatures.length).to.equal(2);
         expect(errors).to.not.be.undefined;
         expect(errors?.length).to.equal(2);
@@ -116,11 +116,11 @@ describe('message verification', () => {
 
     it('verifyMessage - it detects missing signatures', async () => {
         const publicKey = await readKey({ armoredKey: armoredPublicKey });
-        const { verified, signatureTimestamp, signatures, errors } = await verifyMessage({
+        const { verificationStatus, signatureTimestamp, signatures, errors } = await verifyMessage({
             textData: 'no signatures',
             verificationKeys: [publicKey]
         });
-        expect(verified).to.equal(VERIFICATION_STATUS.NOT_SIGNED);
+        expect(verificationStatus).to.equal(VERIFICATION_STATUS.NOT_SIGNED);
         expect(signatures.length).to.equal(0);
         expect(errors).to.be.undefined;
         expect(signatureTimestamp).to.be.null;
@@ -152,11 +152,11 @@ fLz+Lk0ZkB4L3nhM/c6sQKSsI9k2Tptm1VZ5+Qo=
 
         const publicKey = await readKey({ armoredKey });
 
-        const { verified, signatureTimestamp, signatures, errors } = await verifyCleartextMessage({
+        const { verificationStatus, signatureTimestamp, signatures, errors } = await verifyCleartextMessage({
             cleartextMessage: await readCleartextMessage({ cleartextMessage }),
             verificationKeys: [publicKey]
         });
-        expect(verified).to.equal(VERIFICATION_STATUS.SIGNED_AND_VALID);
+        expect(verificationStatus).to.equal(VERIFICATION_STATUS.SIGNED_AND_VALID);
         expect(signatures.length).to.equal(1);
         expect(errors).to.be.undefined;
         expect(signatureTimestamp).to.deep.equal(new Date('Fri, 25 Mar 2022 11:12:34 GMT'));
@@ -178,11 +178,11 @@ fLz+Lk0ZkB4L3nhM/c6sQKSsI9k2Tptm1VZ5+Qo=
 
         const publicKey = await readKey({ armoredKey: armoredPublicKey });
 
-        const { verified, signatureTimestamp, signatures, errors } = await verifyCleartextMessage({
+        const { verificationStatus, signatureTimestamp, signatures, errors } = await verifyCleartextMessage({
             cleartextMessage: await readCleartextMessage({ cleartextMessage }),
             verificationKeys: [publicKey]
         });
-        expect(verified).to.equal(VERIFICATION_STATUS.SIGNED_AND_INVALID);
+        expect(verificationStatus).to.equal(VERIFICATION_STATUS.SIGNED_AND_INVALID);
         expect(signatures.length).to.equal(1);
         expect(errors).to.have.length(1);
         expect(signatureTimestamp).to.be.null;


### PR DESCRIPTION
To avoid confusing it with a boolean value (leading to e.g. `if (verified)`).
