### PR TITLE
Integrate experimental OpenPGP message grammar validation

### DIFF
--- a/lib/key/forwarding.ts
+++ b/lib/key/forwarding.ts
@@ -1,7 +1,8 @@
-import { type PrivateKey, type UserID, type MaybeArray, type SubkeyOptions, type Subkey, KDFParams, enums, SecretSubkeyPacket, type Key, config as defaultConfig } from '../openpgp';
+import { type PrivateKey, type UserID, type SubkeyOptions, type Subkey, KDFParams, enums, SecretSubkeyPacket, type Key, config as defaultConfig } from '../openpgp';
 import { generateKey, reformatKey } from './utils';
 import { serverTime } from '../serverTime';
 import { bigIntToUint8Array, mod, modInv, uint8ArrayToBigInt } from '../bigInteger';
+import type { MaybeArray } from '../utils';
 
 export async function computeProxyParameter(
     forwarderSecret: Uint8Array,

--- a/lib/message/verify.d.ts
+++ b/lib/message/verify.d.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/indent */
 import type {
-    Data,
     VerifyOptions,
     VerifyMessageResult as openpgp_VerifyMessageResult,
     CleartextMessage,
@@ -8,7 +7,7 @@ import type {
 } from '../openpgp';
 import type { VERIFICATION_STATUS } from '../constants';
 import type { ContextVerificationOptions } from './context';
-import type { MaybeWebStream } from '../pmcrypto';
+import type { Data, MaybeWebStream } from '../pmcrypto';
 
 // Streaming not supported when verifying detached signatures
 export interface VerifyOptionsPmcrypto<T extends Data> extends Omit<VerifyOptions, 'message'> {

--- a/lib/openpgp.ts
+++ b/lib/openpgp.ts
@@ -29,6 +29,9 @@ export const setConfig = () => {
     // `checkKeyCompatibility` errors: v5 entities were allowed in pmcrypto v7, so they might have been
     // uploaded as e.g. contact keys.
     config.enableParsingV5Entities = true;
+
+    // Opt-in setting for now to avoid disruptions if too grammar is too strict.
+    config.enforceGrammar = false;
 };
 
 export * from 'openpgp/lightweight';

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
                 "@noble/hashes": "^1.7.1",
                 "@openpgp/web-stream-tools": "~0.1.3",
                 "jsmimeparser": "npm:@protontech/jsmimeparser@^3.0.1",
-                "openpgp": "npm:@protontech/openpgp@~6.1.1-patch.0"
+                "openpgp": "npm:@protontech/openpgp@~6.1.1-patch.2"
             },
             "devDependencies": {
                 "@types/bn.js": "^5.1.6",
@@ -5507,9 +5507,9 @@
         },
         "node_modules/openpgp": {
             "name": "@protontech/openpgp",
-            "version": "6.1.1-patch.0",
-            "resolved": "https://registry.npmjs.org/@protontech/openpgp/-/openpgp-6.1.1-patch.0.tgz",
-            "integrity": "sha512-otlTMfjQUEVQxWt/Y5LIwavdiXt51VR8DVAbiPLGwFDG8pWEpRrJS20/xh/0S28axEY6ViqxKpej1bDQ4um1+g==",
+            "version": "6.1.1-patch.2",
+            "resolved": "https://registry.npmjs.org/@protontech/openpgp/-/openpgp-6.1.1-patch.2.tgz",
+            "integrity": "sha512-Csgb0ZFG3Py6BCqwaE/lyJoGC6oForuRhDs2UWtaaW642zC1m14tDdCZJHVvSoMwKggXrd5pIdM90+dJqTSaew==",
             "license": "LGPL-3.0+",
             "engines": {
                 "node": ">= 18.0.0"

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
         "@openpgp/web-stream-tools": "~0.1.3",
         "@noble/hashes": "^1.7.1",
         "jsmimeparser": "npm:@protontech/jsmimeparser@^3.0.1",
-        "openpgp": "npm:@protontech/openpgp@~6.1.1-patch.0"
+        "openpgp": "npm:@protontech/openpgp@~6.1.1-patch.2"
     },
     "devDependencies": {
         "@types/bn.js": "^5.1.6",


### PR DESCRIPTION
This solution gives us the option to probe whether the grammar is too disruptive in a real-world setting, by testing it in the Proton ecosystem.

See https://github.com/ProtonMail/openpgpjs/pull/18 .